### PR TITLE
Implement Attach node method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,13 +63,20 @@ name = "astarte-message-hub"
 version = "0.1.0"
 dependencies = [
  "astarte_sdk",
+ "async-trait",
  "chrono",
+ "env_logger",
+ "log",
+ "mockall",
  "pbjson-types",
  "prost",
  "serde",
  "thiserror",
+ "tokio",
+ "tokio-stream",
  "tonic",
  "tonic-build",
+ "uuid 1.2.1",
 ]
 
 [[package]]
@@ -142,6 +158,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616896e05fc0e2649463a93a15183c6a16bf03413a7af88ef1285ddedfa9cda5"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -375,6 +402,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +424,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +442,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -434,6 +486,15 @@ checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -477,6 +538,12 @@ checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "futures-channel"
@@ -669,6 +736,12 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -880,6 +953,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +1012,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-integer"
@@ -1170,6 +1276,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
+name = "predicates"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,6 +1431,8 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -1768,6 +1906,21 @@ dependencies = [
  "remove_dir_all",
  "winapi",
 ]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "termtree"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "thiserror"
@@ -2318,6 +2471,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,11 @@ chrono = "0.4.22"
 thiserror = "1.0"
 astarte_sdk = {git ="https://github.com/astarte-platform/astarte-device-sdk-rust.git" }
 serde = "1.0.147"
+tokio = { version = "1.21.0", features = ["rt-multi-thread", "sync", "macros"] }
+tokio-stream = { version = "0.1.9", features = ["net"] }
+log = "0.4.17"
+env_logger = "0.9.0"
+uuid = "1.1.2"
 
 [build-dependencies]
 tonic-build = "0.8.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ tokio-stream = { version = "0.1.9", features = ["net"] }
 log = "0.4.17"
 env_logger = "0.9.0"
 uuid = "1.1.2"
+async-trait = "0.1.56"
+
+[dev-dependencies]
+mockall = "0.11.2"
 
 [build-dependencies]
 tonic-build = "0.8.2"

--- a/src/astarte_message_hub.rs
+++ b/src/astarte_message_hub.rs
@@ -1,0 +1,87 @@
+/*
+ * This file is part of Astarte.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use log::info;
+use tokio::sync::mpsc::Sender;
+use tokio::sync::{mpsc, RwLock};
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status};
+
+use uuid::Uuid;
+
+use crate::proto_message_hub::message_hub_server::MessageHub;
+use crate::proto_message_hub::{AstarteMessage, Interface, Node};
+
+pub struct AstarteMessageHub {
+    pub nodes: Arc<RwLock<HashMap<String, AstarteNode>>>,
+}
+
+pub struct AstarteNode {
+    id: Uuid,
+    introspection: Vec<Interface>,
+    node_channel: Sender<Result<AstarteMessage, Status>>,
+}
+
+#[tonic::async_trait]
+impl MessageHub for AstarteMessageHub {
+    type AttachStream = ReceiverStream<Result<AstarteMessage, Status>>;
+
+    async fn attach(&self, request: Request<Node>) -> Result<Response<Self::AttachStream>, Status> {
+        info!("Node Attach Request => {:?}", request);
+        let node = request.into_inner();
+
+        let id = Uuid::parse_str(&node.uuid).map_err(|err| {
+            Status::invalid_argument(format!(
+                "Unable to parse UUID value, err{:?}",
+                err.to_string()
+            ))
+        })?;
+
+        let (tx, rx) = mpsc::channel(4);
+
+        let astarte_node = AstarteNode {
+            id,
+            introspection: node.introspection,
+            node_channel: tx,
+        };
+
+        let mut nodes = self.nodes.write().await;
+        nodes.insert(astarte_node.id.to_string(), astarte_node);
+
+        Ok(Response::new(ReceiverStream::new(rx)))
+    }
+
+    async fn send(
+        &self,
+        _request: Request<AstarteMessage>,
+    ) -> Result<Response<pbjson_types::Empty>, Status> {
+        todo!()
+    }
+
+    async fn detach(
+        &self,
+        _request: Request<Node>,
+    ) -> Result<Response<pbjson_types::Empty>, Status> {
+        todo!()
+    }
+}

--- a/src/data/astarte.rs
+++ b/src/data/astarte.rs
@@ -18,11 +18,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    env_logger::init();
+use std::io::Error;
 
-    //TODO add MessageHubServer and add Astarte::new() on top of AstarteSDK
+use async_trait::async_trait;
+use tokio::sync::mpsc::Receiver;
+use tonic::Status;
 
-    Ok(())
+use crate::astarte_message_hub::AstarteNode;
+use crate::proto_message_hub::AstarteMessage;
+
+#[async_trait]
+pub trait AstartePublisher: Send + Sync {
+    async fn publish(&self, astarte_message: AstarteMessage) -> Result<(), Error>;
+}
+
+#[async_trait]
+pub trait AstarteSubscriber {
+    async fn subscribe(
+        &self,
+        astarte_node: &AstarteNode,
+    ) -> Result<Receiver<Result<AstarteMessage, Status>>, Error>;
+    async fn unsubscribe(&self, astarte_node: &AstarteNode) -> Result<(), Error>;
 }

--- a/src/data/astarte_provider.rs
+++ b/src/data/astarte_provider.rs
@@ -1,0 +1,100 @@
+/*
+ * This file is part of Astarte.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::collections::HashMap;
+use std::io::Error;
+use std::sync::Arc;
+
+use astarte_sdk::AstarteSdk;
+use async_trait::async_trait;
+use log::warn;
+use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tokio::sync::RwLock;
+use tonic::Status;
+use uuid::Uuid;
+
+use crate::astarte_message_hub::AstarteNode;
+use crate::data::astarte::AstarteSubscriber;
+use crate::proto_message_hub;
+use crate::proto_message_hub::AstarteMessage;
+
+#[derive(Clone)]
+pub struct Astarte {
+    pub device_sdk: AstarteSdk,
+    subscribers: Arc<RwLock<HashMap<Uuid, Subscriber>>>,
+}
+
+struct Subscriber {
+    introspection: Vec<proto_message_hub::Interface>,
+    sender: Sender<Result<AstarteMessage, Status>>,
+}
+
+#[async_trait]
+impl AstarteSubscriber for Astarte {
+    async fn subscribe(
+        &self,
+        astarte_node: &AstarteNode,
+    ) -> Result<Receiver<Result<AstarteMessage, Status>>, Error> {
+        let (tx, rx) = channel(32);
+        self.subscribers.write().await.insert(
+            astarte_node.id.clone(),
+            Subscriber {
+                introspection: astarte_node.introspection.clone(),
+                sender: tx,
+            },
+        );
+        Ok(rx)
+    }
+
+    async fn unsubscribe(&self, _astarte_node: &AstarteNode) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+impl Astarte {
+    pub async fn run(&mut self) {
+        if let Ok(clientbound) = self.device_sdk.poll().await {
+            println!("incoming: {:?}", clientbound);
+
+            if let Ok(astarte_message) = AstarteMessage::try_from(clientbound.clone()) {
+                let subscribers_guard = self.subscribers.read().await;
+                let subscribers = subscribers_guard
+                    .iter()
+                    .filter(|(_, subscriber)| {
+                        subscriber
+                            .introspection
+                            .iter()
+                            .map(|iface| iface.name.clone())
+                            .collect::<String>()
+                            .contains(&clientbound.interface)
+                    })
+                    .map(|(_, subscriber)| subscriber);
+                for subscriber in subscribers {
+                    let _ = subscriber.sender.send(Ok(astarte_message.clone())).await;
+                }
+            } else {
+                warn!(
+                    "Unable to convert clientbound to AstarteMessage: {:?}",
+                    clientbound
+                );
+            }
+        }
+    }
+}

--- a/src/data/mock_astarte.rs
+++ b/src/data/mock_astarte.rs
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Astarte.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use astarte_sdk::types::AstarteType;
+use astarte_sdk::{AstarteError, Clientbound};
+use mockall::automock;
+
+pub struct AstarteSdk {}
+
+#[cfg_attr(test, automock)]
+impl AstarteSdk {
+    pub async fn poll(&mut self) -> Result<Clientbound, AstarteError> {
+        todo!()
+    }
+    pub async fn send<D: 'static>(
+        &self,
+        _interface_name: &str,
+        _interface_path: &str,
+        _data: D,
+    ) -> Result<(), AstarteError>
+    where
+        D: Into<AstarteType>,
+    {
+        todo!()
+    }
+    pub async fn send_with_timestamp<D: 'static>(
+        &self,
+        _interface_name: &str,
+        _interface_path: &str,
+        _data: D,
+        _timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), AstarteError>
+    where
+        D: Into<AstarteType>,
+    {
+        todo!()
+    }
+    pub async fn send_object<T: 'static>(
+        &self,
+        _interface_name: &str,
+        _interface_path: &str,
+        _data: T,
+    ) -> Result<(), AstarteError>
+    where
+        T: serde::Serialize,
+    {
+        todo!()
+    }
+    pub async fn send_object_with_timestamp<T: 'static>(
+        &self,
+        _interface_name: &str,
+        _interface_path: &str,
+        _data: T,
+        _timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), AstarteError>
+    where
+        T: serde::Serialize,
+    {
+        todo!()
+    }
+    pub async fn unset<D: 'static>(
+        &self,
+        _interface_name: &str,
+        _interface_path: &str,
+    ) -> Result<(), AstarteError>
+    where
+        D: Into<AstarteType>,
+    {
+        todo!()
+    }
+}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -19,3 +19,4 @@
  */
 
 pub(crate) mod astarte;
+pub mod astarte_provider;

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -20,3 +20,6 @@
 
 pub(crate) mod astarte;
 pub mod astarte_provider;
+
+#[cfg(test)]
+mod mock_astarte;

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -18,11 +18,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    env_logger::init();
-
-    //TODO add MessageHubServer and add Astarte::new() on top of AstarteSDK
-
-    Ok(())
-}
+pub(crate) mod astarte;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+pub use crate::astarte_message_hub::AstarteMessageHub;
 pub use crate::proto_message_hub::message_hub_server::MessageHubServer;
 
+mod astarte_message_hub;
 mod astarte_sdk_types;
 mod error;
 mod types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub use crate::proto_message_hub::message_hub_server::MessageHubServer;
 
 mod astarte_message_hub;
 mod astarte_sdk_types;
+mod data;
 mod error;
 mod types;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-fn main() {
-    println!("Astarte-message-hub!");
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use log::info;
+use tokio::sync::RwLock;
+use tonic::transport::Server;
+
+use astarte_message_hub::AstarteMessageHub;
+use astarte_message_hub::MessageHubServer;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    let addr: SocketAddr = "[::1]:10000".parse().unwrap();
+
+    let astarte_message_hub = AstarteMessageHub {
+        nodes: Arc::new(RwLock::new(HashMap::new())),
+    };
+
+    let astarte_message_server = MessageHubServer::new(astarte_message_hub);
+    Server::builder()
+        .add_service(astarte_message_server)
+        .serve(addr)
+        .await?;
+    info!("Astarte Message Hub listening on: {}", addr);
+
+    Ok(())
 }


### PR DESCRIPTION
- Add `AstartePublisher` and `AstarteSubscriber` traits. This allows the AstarteSDK to be encapsulated behind Publisher/Subscriber traits, decoupling the collection and delivery of messages from the communication with Astarte broker and also improves the testability of the project.

- The attach method returns an `AttachStream` type,where will be redirected all Astarte Data event received by the Node Attached.

- Add node client example

Closes #12, closes #28.