### PR TITLE
Implement type conversion for AstarteDataType

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,15 +8,25 @@
 version = 3
 
 [[package]]
-name = "anyhow"
-version = "1.0.63"
+name = "android_system_properties"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26fa4d7e3f2eebadf743988fc8aec9fa9a9e82611acafd77c1462ed6262440a"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
 name = "astarte-message-hub"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "prost",
  "prost-types",
  "tonic",
@@ -63,9 +73,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de18bc5f2e9df8f52da03856bf40e29b747de5a84e43aefff90e3dc4a21529b"
+checksum = "c9e3356844c4d6a6d6467b8da2cffb4a2820be256f50a3a386c9d152bab31043"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -92,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f44a0e6200e9d11a1cdc989e4b358f6e3d354fbf48478f345a17f4e43f8635"
+checksum = "d9f0c0a60006f2a293d82d571f635042a72edf927539b7685bd62d361963839b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -102,6 +112,8 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -117,6 +129,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bumpalo"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+
+[[package]]
 name = "bytes"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +145,27 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "time",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "either"
@@ -202,7 +241,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -313,6 +352,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "237a0714f28b1ee39ccec0770ccb544eb02c9ef2c82bb096230eefcffa6468b0"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -347,6 +400,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
+name = "js-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,9 +416,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
 name = "log"
@@ -393,7 +455,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -404,16 +466,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
-name = "once_cell"
-version = "1.13.1"
+name = "num-integer"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "petgraph"
@@ -567,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
@@ -624,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10c98bba371b9b22a71a9414e420f92ddeb2369239af08200816169d5e2dd7aa"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
@@ -634,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -664,10 +745,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.20.1"
+name = "time"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "tokio"
+version = "1.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
 dependencies = [
  "autocfg",
  "bytes",
@@ -704,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
+checksum = "f6edf2d6bc038a43d31353570e27270603f4648d18f5ed10c0e179abe43255af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -715,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
 dependencies = [
  "bytes",
  "futures-core",
@@ -729,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498f271adc46acce75d66f639e4d35b31b2394c295c82496727dafa16d465dd2"
+checksum = "11cd56bdb54ef93935a6a79dbd1d91f1ebd4c64150fd61654031fd6b8b775c91"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -874,9 +966,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "want"
@@ -890,9 +982,69 @@ dependencies = [
 
 [[package]]
 name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2021"
 tonic = "0.8.0"
 prost = "0.11.0"
 prost-types = "0.11.1"
+chrono = "0.4.22"
 
 [build-dependencies]
 tonic-build = "0.8.0"

--- a/proto/astarteplatform/msghub/astarte_type.proto
+++ b/proto/astarteplatform/msghub/astarte_type.proto
@@ -25,31 +25,31 @@ package astarteplatform.msghub;
 import "google/protobuf/timestamp.proto";
 
 message AstarteDoubleArray {
-  repeated double astarte_double = 1;
+  repeated double values = 1;
 }
 
 message AstarteIntegerArray {
-  repeated int32 astarte_integer = 1;
+  repeated int32 values = 1;
 }
 
 message AstarteBooleanArray {
-  repeated bool astarte_boolean = 1;
+  repeated bool values = 1;
 }
 
 message AstarteLongIntegerArray {
-  repeated int64 astarte_long_integer = 1;
+  repeated int64 values = 1;
 }
 
 message AstarteStringArray {
-  repeated string astarte_string = 1;
+  repeated string values = 1;
 }
 
 message AstarteBinaryBlobArray {
-  repeated bytes astarte_binary_blob = 1;
+  repeated bytes values = 1;
 }
 
 message AstarteDateTimeArray{
-  repeated google.protobuf.Timestamp astarte_date_time = 1;
+  repeated google.protobuf.Timestamp values = 1;
 }
 
 message AstarteDataTypeObject {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,3 +17,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+pub use crate::proto_message_hub::message_hub_server::MessageHubServer;
+
+mod types;
+
+pub mod proto_message_hub {
+    tonic::include_proto!("astarteplatform.msghub");
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -54,6 +54,21 @@ macro_rules! impl_type_conversion_traits {
     };
 }
 
+macro_rules! impl_array_type_conversion_traits {
+    ( {$( ($typ:ty, $astartedatatype:ident) ,)*}) => {
+
+        $(
+               impl From<$typ> for AstarteDataTypeIndividual {
+                    fn from(values: $typ) -> Self {
+                        AstarteDataTypeIndividual {
+                            individual_data: Some(IndividualData::$astartedatatype($astartedatatype{values}))
+                        }
+                    }
+                }
+        )*
+    };
+}
+
 impl_type_conversion_traits!({
     (f64, AstarteDouble),
     (i32, AstarteInteger),
@@ -62,6 +77,15 @@ impl_type_conversion_traits!({
     (&str, AstarteString),
     (String, AstarteString),
     (Vec<u8>, AstarteBinaryBlob),
+});
+
+impl_array_type_conversion_traits!({
+    (Vec<f64>, AstarteDoubleArray),
+    (Vec<i32>, AstarteIntegerArray),
+    (Vec<bool>, AstarteBooleanArray),
+    (Vec<i64>, AstarteLongIntegerArray),
+    (Vec<String>, AstarteStringArray),
+    (Vec<Vec<u8>>, AstarteBinaryBlobArray),
 });
 
 impl From<DateTime<Utc>> for AstarteDataTypeIndividual {
@@ -74,76 +98,12 @@ impl From<DateTime<Utc>> for AstarteDataTypeIndividual {
     }
 }
 
-impl From<Vec<f64>> for AstarteDataTypeIndividual {
-    fn from(value: Vec<f64>) -> Self {
-        AstarteDataTypeIndividual {
-            individual_data: Some(IndividualData::AstarteDoubleArray(AstarteDoubleArray {
-                astarte_double: value,
-            })),
-        }
-    }
-}
-
-impl From<Vec<i32>> for AstarteDataTypeIndividual {
-    fn from(value: Vec<i32>) -> Self {
-        AstarteDataTypeIndividual {
-            individual_data: Some(IndividualData::AstarteIntegerArray(AstarteIntegerArray {
-                astarte_integer: value,
-            })),
-        }
-    }
-}
-
-impl From<Vec<i64>> for AstarteDataTypeIndividual {
-    fn from(value: Vec<i64>) -> Self {
-        AstarteDataTypeIndividual {
-            individual_data: Some(IndividualData::AstarteLongIntegerArray(
-                AstarteLongIntegerArray {
-                    astarte_long_integer: value,
-                },
-            )),
-        }
-    }
-}
-
-impl From<Vec<bool>> for AstarteDataTypeIndividual {
-    fn from(value: Vec<bool>) -> Self {
-        AstarteDataTypeIndividual {
-            individual_data: Some(IndividualData::AstarteBooleanArray(AstarteBooleanArray {
-                astarte_boolean: value,
-            })),
-        }
-    }
-}
-
-impl From<Vec<String>> for AstarteDataTypeIndividual {
-    fn from(value: Vec<String>) -> Self {
-        AstarteDataTypeIndividual {
-            individual_data: Some(IndividualData::AstarteStringArray(AstarteStringArray {
-                astarte_string: value,
-            })),
-        }
-    }
-}
-
-impl From<Vec<Vec<u8>>> for AstarteDataTypeIndividual {
-    fn from(value: Vec<Vec<u8>>) -> Self {
-        AstarteDataTypeIndividual {
-            individual_data: Some(IndividualData::AstarteBinaryBlobArray(
-                AstarteBinaryBlobArray {
-                    astarte_binary_blob: value,
-                },
-            )),
-        }
-    }
-}
-
 impl From<Vec<DateTime<Utc>>> for AstarteDataTypeIndividual {
-    fn from(value: Vec<DateTime<Utc>>) -> Self {
+    fn from(values: Vec<DateTime<Utc>>) -> Self {
         use prost_types::Timestamp;
         AstarteDataTypeIndividual {
             individual_data: Some(IndividualData::AstarteDateTimeArray(AstarteDateTimeArray {
-                astarte_date_time: value
+                values: values
                     .iter()
                     .map(|x| {
                         let system_time: SystemTime = x.clone().into();
@@ -279,7 +239,7 @@ mod test {
         if let IndividualData::AstarteDoubleArray(vec_double_values) =
             vec_double_individual_type.individual_data.unwrap()
         {
-            assert_eq!(expected_vec_double_value, vec_double_values.astarte_double);
+            assert_eq!(expected_vec_double_value, vec_double_values.values);
         } else {
             panic!();
         }
@@ -294,7 +254,7 @@ mod test {
         if let IndividualData::AstarteStringArray(vec_string_values) =
             vec_string_individual_type.individual_data.unwrap()
         {
-            assert_eq!(expected_vec_string_value, vec_string_values.astarte_string);
+            assert_eq!(expected_vec_string_value, vec_string_values.values);
         } else {
             panic!();
         }
@@ -445,7 +405,7 @@ mod test {
             if let IndividualData::AstarteDoubleArray(vec_double_values) =
                 data.individual_data.unwrap()
             {
-                assert_eq!(expected_vec_double_value, vec_double_values.astarte_double);
+                assert_eq!(expected_vec_double_value, vec_double_values.values);
             } else {
                 panic!();
             }
@@ -463,7 +423,7 @@ mod test {
             if let IndividualData::AstarteIntegerArray(vec_i32_values) =
                 data.individual_data.unwrap()
             {
-                assert_eq!(expected_vec_i32_value, vec_i32_values.astarte_integer);
+                assert_eq!(expected_vec_i32_value, vec_i32_values.values);
             } else {
                 panic!();
             }
@@ -481,7 +441,7 @@ mod test {
             if let IndividualData::AstarteLongIntegerArray(vec_i64_values) =
                 data.individual_data.unwrap()
             {
-                assert_eq!(expected_vec_i64_value, vec_i64_values.astarte_long_integer);
+                assert_eq!(expected_vec_i64_value, vec_i64_values.values);
             } else {
                 panic!();
             }
@@ -499,7 +459,7 @@ mod test {
             if let IndividualData::AstarteBooleanArray(vec_bool_values) =
                 data.individual_data.unwrap()
             {
-                assert_eq!(expected_vec_bool_value, vec_bool_values.astarte_boolean);
+                assert_eq!(expected_vec_bool_value, vec_bool_values.values);
             } else {
                 panic!();
             }
@@ -518,7 +478,7 @@ mod test {
             if let IndividualData::AstarteStringArray(vec_string_values) =
                 data.individual_data.unwrap()
             {
-                assert_eq!(expected_vec_string_value, vec_string_values.astarte_string);
+                assert_eq!(expected_vec_string_value, vec_string_values.values);
             } else {
                 panic!();
             }
@@ -539,7 +499,7 @@ mod test {
             {
                 assert_eq!(
                     expected_vec_binary_blob_value,
-                    vec_binary_blob_values.astarte_binary_blob
+                    vec_binary_blob_values.values
                 );
             } else {
                 panic!();
@@ -564,7 +524,7 @@ mod test {
             {
                 for i in 0..expected_vec_datetime_value.len() {
                     let system_time: SystemTime = vec_datetime_value
-                        .astarte_date_time
+                        .values
                         .get(i)
                         .unwrap()
                         .clone()

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,627 @@
+/*
+ * This file is part of Astarte.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::collections::HashMap;
+use std::time::SystemTime;
+
+use chrono::{DateTime, Utc};
+
+use crate::proto_message_hub::astarte_data_type::Data::{AstarteIndividual, AstarteObject};
+use crate::proto_message_hub::astarte_data_type_individual::IndividualData;
+use crate::proto_message_hub::{
+    AstarteBinaryBlobArray, AstarteBooleanArray, AstarteDataType, AstarteDataTypeIndividual,
+    AstarteDataTypeObject, AstarteDateTimeArray, AstarteDoubleArray, AstarteIntegerArray,
+    AstarteLongIntegerArray, AstarteStringArray,
+};
+
+macro_rules! impl_type_conversion_traits {
+    ( {$( ($typ:ty, $astartedatatype:ident) ,)*}) => {
+
+        $(
+               impl From<$typ> for AstarteDataTypeIndividual {
+                    fn from(d: $typ) -> Self {
+                        AstarteDataTypeIndividual {
+                            individual_data: Some(IndividualData::$astartedatatype(d.into())),
+                        }
+                    }
+                }
+
+                impl From<&$typ> for AstarteDataTypeIndividual {
+                    fn from(d: &$typ) -> Self {
+                        AstarteDataTypeIndividual {
+                            individual_data: Some(IndividualData::$astartedatatype(d.clone().into())),
+                        }
+                    }
+                }
+        )*
+    };
+}
+
+impl_type_conversion_traits!({
+    (f64, AstarteDouble),
+    (i32, AstarteInteger),
+    (bool, AstarteBoolean),
+    (i64, AstarteLongInteger),
+    (&str, AstarteString),
+    (String, AstarteString),
+    (Vec<u8>, AstarteBinaryBlob),
+});
+
+impl From<DateTime<Utc>> for AstarteDataTypeIndividual {
+    fn from(value: DateTime<Utc>) -> Self {
+        let system_time: SystemTime = value.into();
+
+        AstarteDataTypeIndividual {
+            individual_data: Some(IndividualData::AstarteDateTime(system_time.into())),
+        }
+    }
+}
+
+impl From<Vec<f64>> for AstarteDataTypeIndividual {
+    fn from(value: Vec<f64>) -> Self {
+        AstarteDataTypeIndividual {
+            individual_data: Some(IndividualData::AstarteDoubleArray(AstarteDoubleArray {
+                astarte_double: value,
+            })),
+        }
+    }
+}
+
+impl From<Vec<i32>> for AstarteDataTypeIndividual {
+    fn from(value: Vec<i32>) -> Self {
+        AstarteDataTypeIndividual {
+            individual_data: Some(IndividualData::AstarteIntegerArray(AstarteIntegerArray {
+                astarte_integer: value,
+            })),
+        }
+    }
+}
+
+impl From<Vec<i64>> for AstarteDataTypeIndividual {
+    fn from(value: Vec<i64>) -> Self {
+        AstarteDataTypeIndividual {
+            individual_data: Some(IndividualData::AstarteLongIntegerArray(
+                AstarteLongIntegerArray {
+                    astarte_long_integer: value,
+                },
+            )),
+        }
+    }
+}
+
+impl From<Vec<bool>> for AstarteDataTypeIndividual {
+    fn from(value: Vec<bool>) -> Self {
+        AstarteDataTypeIndividual {
+            individual_data: Some(IndividualData::AstarteBooleanArray(AstarteBooleanArray {
+                astarte_boolean: value,
+            })),
+        }
+    }
+}
+
+impl From<Vec<String>> for AstarteDataTypeIndividual {
+    fn from(value: Vec<String>) -> Self {
+        AstarteDataTypeIndividual {
+            individual_data: Some(IndividualData::AstarteStringArray(AstarteStringArray {
+                astarte_string: value,
+            })),
+        }
+    }
+}
+
+impl From<Vec<Vec<u8>>> for AstarteDataTypeIndividual {
+    fn from(value: Vec<Vec<u8>>) -> Self {
+        AstarteDataTypeIndividual {
+            individual_data: Some(IndividualData::AstarteBinaryBlobArray(
+                AstarteBinaryBlobArray {
+                    astarte_binary_blob: value,
+                },
+            )),
+        }
+    }
+}
+
+impl From<Vec<DateTime<Utc>>> for AstarteDataTypeIndividual {
+    fn from(value: Vec<DateTime<Utc>>) -> Self {
+        use prost_types::Timestamp;
+        AstarteDataTypeIndividual {
+            individual_data: Some(IndividualData::AstarteDateTimeArray(AstarteDateTimeArray {
+                astarte_date_time: value
+                    .iter()
+                    .map(|x| {
+                        let system_time: SystemTime = x.clone().into();
+                        system_time.into()
+                    })
+                    .collect::<Vec<Timestamp>>(),
+            })),
+        }
+    }
+}
+
+impl<T> From<T> for AstarteDataType
+where
+    T: Into<AstarteDataTypeIndividual>,
+{
+    fn from(value: T) -> Self {
+        AstarteDataType {
+            data: Some(AstarteIndividual(value.into())),
+        }
+    }
+}
+
+impl From<HashMap<String, AstarteDataTypeIndividual>> for AstarteDataType {
+    fn from(value: HashMap<String, AstarteDataTypeIndividual>) -> Self {
+        AstarteDataType {
+            data: Some(AstarteObject(AstarteDataTypeObject { object_data: value })),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+
+    use crate::proto_message_hub::astarte_data_type::Data::AstarteIndividual;
+    use crate::proto_message_hub::astarte_data_type_individual::IndividualData;
+    use crate::proto_message_hub::AstarteDataType;
+    use crate::proto_message_hub::AstarteDataTypeIndividual;
+
+    #[test]
+    fn from_double_to_astarte_individual_type_success() {
+        let expected_double_value: f64 = 15.5;
+        let d_astarte_individual_type: AstarteDataTypeIndividual =
+            AstarteDataTypeIndividual::from(expected_double_value);
+
+        if let IndividualData::AstarteDouble(double_value) =
+            d_astarte_individual_type.individual_data.unwrap()
+        {
+            assert_eq!(expected_double_value, double_value);
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn from_double_by_ref_to_astarte_individual_type_success() {
+        let expected_double_value: f64 = 15.5;
+        let d_astarte_individual_type: AstarteDataTypeIndividual =
+            AstarteDataTypeIndividual::from(&expected_double_value);
+
+        if let IndividualData::AstarteDouble(double_value) =
+            d_astarte_individual_type.individual_data.unwrap()
+        {
+            assert_eq!(expected_double_value, double_value);
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn double_into_astarte_individual_type_success() {
+        let expected_double_value: f64 = 15.5;
+        let d_astarte_individual_type: AstarteDataTypeIndividual = expected_double_value.into();
+
+        if let IndividualData::AstarteDouble(double_value) =
+            d_astarte_individual_type.individual_data.unwrap()
+        {
+            assert_eq!(expected_double_value, double_value);
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn integer_into_astarte_individual_type_success() {
+        let expected_integer_value: i32 = 15;
+        let i32_individual_data_type: AstarteDataTypeIndividual = expected_integer_value.into();
+
+        if let IndividualData::AstarteInteger(i32_value) =
+            i32_individual_data_type.individual_data.unwrap()
+        {
+            assert_eq!(expected_integer_value, i32_value);
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn bool_into_astarte_individual_type_success() {
+        let expected_bool_value: bool = true;
+        let bool_individual_data_type: AstarteDataTypeIndividual = expected_bool_value.into();
+
+        if let IndividualData::AstarteBoolean(bool_value) =
+            bool_individual_data_type.individual_data.unwrap()
+        {
+            assert_eq!(expected_bool_value, bool_value);
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn u8_array_into_individual_type_success() {
+        let expected_vec_u8_value: Vec<u8> = vec![10, 44];
+        let vec_u8_astarte_individual_type: AstarteDataTypeIndividual =
+            expected_vec_u8_value.clone().into();
+
+        if let IndividualData::AstarteBinaryBlob(vec_u8_values) =
+            vec_u8_astarte_individual_type.individual_data.unwrap()
+        {
+            assert_eq!(expected_vec_u8_value, vec_u8_values);
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn double_array_into_individual_type_success() {
+        let expected_vec_double_value: Vec<f64> = vec![10.54, 44.99];
+        let vec_double_individual_type: AstarteDataTypeIndividual =
+            expected_vec_double_value.clone().into();
+
+        if let IndividualData::AstarteDoubleArray(vec_double_values) =
+            vec_double_individual_type.individual_data.unwrap()
+        {
+            assert_eq!(expected_vec_double_value, vec_double_values.astarte_double);
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn string_array_into_individual_type_success() {
+        let expected_vec_string_value: Vec<String> = vec!["test1".to_owned(), "test2".to_owned()];
+        let vec_string_individual_type: AstarteDataTypeIndividual =
+            expected_vec_string_value.clone().into();
+
+        if let IndividualData::AstarteStringArray(vec_string_values) =
+            vec_string_individual_type.individual_data.unwrap()
+        {
+            assert_eq!(expected_vec_string_value, vec_string_values.astarte_string);
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn double_into_astarte_data_type_success() {
+        let expected_double_value: f64 = 15.5;
+        let d_astarte_data_type: AstarteDataType = expected_double_value.into();
+
+        if let AstarteIndividual(data) = d_astarte_data_type.data.unwrap() {
+            if let IndividualData::AstarteDouble(double_value) = data.individual_data.unwrap() {
+                assert_eq!(expected_double_value, double_value);
+            } else {
+                panic!();
+            }
+        } else {
+            panic!()
+        }
+    }
+
+    #[test]
+    fn integer_into_astarte_data_type_success() {
+        let expected_integer_value: i32 = 15;
+        let i32_astarte_data_type: AstarteDataType = expected_integer_value.into();
+
+        if let AstarteIndividual(data) = i32_astarte_data_type.data.unwrap() {
+            if let IndividualData::AstarteInteger(i32_value) = data.individual_data.unwrap() {
+                assert_eq!(expected_integer_value, i32_value);
+            } else {
+                panic!();
+            }
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn bool_into_astarte_data_type_success() {
+        let expected_bool_value: bool = true;
+        let bool_astarte_data_type: AstarteDataType = expected_bool_value.into();
+
+        if let AstarteIndividual(data) = bool_astarte_data_type.data.unwrap() {
+            if let IndividualData::AstarteBoolean(bool_value) = data.individual_data.unwrap() {
+                assert_eq!(expected_bool_value, bool_value);
+            } else {
+                panic!();
+            }
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn longinteger_into_astarte_data_type_success() {
+        let expected_longinteger_value: i64 = 15;
+        let i64_astarte_data_type: AstarteDataType = expected_longinteger_value.into();
+
+        if let AstarteIndividual(data) = i64_astarte_data_type.data.unwrap() {
+            if let IndividualData::AstarteLongInteger(i64_value) = data.individual_data.unwrap() {
+                assert_eq!(expected_longinteger_value, i64_value);
+            } else {
+                panic!();
+            }
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn string_into_astarte_data_type_success() {
+        let expected_string_value: String = "15".to_owned();
+        let string_astarte_data_type: AstarteDataType = expected_string_value.clone().into();
+
+        if let AstarteIndividual(data) = string_astarte_data_type.data.unwrap() {
+            if let IndividualData::AstarteString(string_value) = data.individual_data.unwrap() {
+                assert_eq!(expected_string_value, string_value);
+            } else {
+                panic!();
+            }
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn strings_slice_into_astarte_data_type_success() {
+        let expected_string_value: &str = "15";
+        let string_astarte_data_type: AstarteDataType = expected_string_value.into();
+
+        if let AstarteIndividual(data) = string_astarte_data_type.data.unwrap() {
+            if let IndividualData::AstarteString(string_value) = data.individual_data.unwrap() {
+                assert_eq!(expected_string_value, string_value);
+            } else {
+                panic!();
+            }
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn u8_array_into_astarte_data_type_success() {
+        let expected_vec_u8_value: Vec<u8> = vec![10, 44];
+        let vec_u8_astarte_data_type: AstarteDataType = expected_vec_u8_value.clone().into();
+
+        if let AstarteIndividual(data) = vec_u8_astarte_data_type.data.unwrap() {
+            if let IndividualData::AstarteBinaryBlob(vec_u8_values) = data.individual_data.unwrap()
+            {
+                assert_eq!(expected_vec_u8_value, vec_u8_values);
+            } else {
+                panic!();
+            }
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn datetime_into_astarte_data_type_success() {
+        use chrono::Utc;
+        use std::time::SystemTime;
+
+        let expected_datetime_value = Utc::now();
+
+        let datetime_astarte_data_type: AstarteDataType = expected_datetime_value.clone().into();
+
+        if let AstarteIndividual(data) = datetime_astarte_data_type.data.unwrap() {
+            if let IndividualData::AstarteDateTime(date_time_value) = data.individual_data.unwrap()
+            {
+                let expected_sys_time: SystemTime = expected_datetime_value.into();
+                assert_eq!(expected_sys_time, date_time_value.try_into().unwrap());
+            } else {
+                panic!();
+            }
+        } else {
+            panic!()
+        }
+    }
+
+    #[test]
+    fn double_array_into_astarte_data_type_success() {
+        let expected_vec_double_value: Vec<f64> = vec![10.54, 44.99];
+        let vec_double_astarte_data_type: AstarteDataType =
+            expected_vec_double_value.clone().into();
+
+        if let AstarteIndividual(data) = vec_double_astarte_data_type.data.unwrap() {
+            if let IndividualData::AstarteDoubleArray(vec_double_values) =
+                data.individual_data.unwrap()
+            {
+                assert_eq!(expected_vec_double_value, vec_double_values.astarte_double);
+            } else {
+                panic!();
+            }
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn integer_array_into_astarte_data_type_success() {
+        let expected_vec_i32_value: Vec<i32> = vec![10, 44];
+        let vec_i32_astarte_data_type: AstarteDataType = expected_vec_i32_value.clone().into();
+
+        if let AstarteIndividual(data) = vec_i32_astarte_data_type.data.unwrap() {
+            if let IndividualData::AstarteIntegerArray(vec_i32_values) =
+                data.individual_data.unwrap()
+            {
+                assert_eq!(expected_vec_i32_value, vec_i32_values.astarte_integer);
+            } else {
+                panic!();
+            }
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn long_integer_array_into_astarte_data_type_success() {
+        let expected_vec_i64_value: Vec<i64> = vec![10, 44];
+        let vec_i64_astarte_data_type: AstarteDataType = expected_vec_i64_value.clone().into();
+
+        if let AstarteIndividual(data) = vec_i64_astarte_data_type.data.unwrap() {
+            if let IndividualData::AstarteLongIntegerArray(vec_i64_values) =
+                data.individual_data.unwrap()
+            {
+                assert_eq!(expected_vec_i64_value, vec_i64_values.astarte_long_integer);
+            } else {
+                panic!();
+            }
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn bool_array_into_astarte_data_type_success() {
+        let expected_vec_bool_value: Vec<bool> = vec![false, true];
+        let vec_bool_astarte_data_type: AstarteDataType = expected_vec_bool_value.clone().into();
+
+        if let AstarteIndividual(data) = vec_bool_astarte_data_type.data.unwrap() {
+            if let IndividualData::AstarteBooleanArray(vec_bool_values) =
+                data.individual_data.unwrap()
+            {
+                assert_eq!(expected_vec_bool_value, vec_bool_values.astarte_boolean);
+            } else {
+                panic!();
+            }
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn string_array_into_astarte_data_type_success() {
+        let expected_vec_string_value: Vec<String> = vec!["test1".to_owned(), "test2".to_owned()];
+        let vec_string_astarte_data_type: AstarteDataType =
+            expected_vec_string_value.clone().into();
+
+        if let AstarteIndividual(data) = vec_string_astarte_data_type.data.unwrap() {
+            if let IndividualData::AstarteStringArray(vec_string_values) =
+                data.individual_data.unwrap()
+            {
+                assert_eq!(expected_vec_string_value, vec_string_values.astarte_string);
+            } else {
+                panic!();
+            }
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn binary_blob_array_into_astarte_data_type_success() {
+        let expected_vec_binary_blob_value: Vec<Vec<u8>> = vec![vec![12, 245], vec![78, 11, 128]];
+        let vec_binary_blob_astarte_data_type: AstarteDataType =
+            expected_vec_binary_blob_value.clone().into();
+
+        if let AstarteIndividual(data) = vec_binary_blob_astarte_data_type.data.unwrap() {
+            if let IndividualData::AstarteBinaryBlobArray(vec_binary_blob_values) =
+                data.individual_data.unwrap()
+            {
+                assert_eq!(
+                    expected_vec_binary_blob_value,
+                    vec_binary_blob_values.astarte_binary_blob
+                );
+            } else {
+                panic!();
+            }
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn datetime_array_into_astarte_data_type_success() {
+        use chrono::{DateTime, Utc};
+        use std::time::SystemTime;
+
+        let expected_vec_datetime_value = vec![Utc::now(), Utc::now()];
+        let vec_datetime_astarte_data_type: AstarteDataType =
+            expected_vec_datetime_value.clone().into();
+
+        if let AstarteIndividual(data) = vec_datetime_astarte_data_type.data.unwrap() {
+            if let IndividualData::AstarteDateTimeArray(vec_datetime_value) =
+                data.individual_data.unwrap()
+            {
+                for i in 0..expected_vec_datetime_value.len() {
+                    let system_time: SystemTime = vec_datetime_value
+                        .astarte_date_time
+                        .get(i)
+                        .unwrap()
+                        .clone()
+                        .try_into()
+                        .unwrap();
+
+                    let date_time: DateTime<Utc> = system_time.try_into().unwrap();
+                    assert_eq!(expected_vec_datetime_value.get(i).unwrap(), &date_time);
+                }
+            } else {
+                panic!();
+            }
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn map_into_astarte_data_type_success() {
+        use crate::proto_message_hub::astarte_data_type::Data::AstarteObject;
+        use crate::proto_message_hub::AstarteDataTypeIndividual;
+
+        let expected_i32 = 5;
+        let expected_f64 = 5.12;
+        let mut map_val: HashMap<String, AstarteDataTypeIndividual> = HashMap::new();
+        map_val.insert("i32".to_owned(), expected_i32.into());
+        map_val.insert("f64".to_owned(), expected_f64.into());
+
+        let astarte_data_object: AstarteDataType = map_val.into();
+
+        if let AstarteObject(data) = astarte_data_object.data.unwrap() {
+            if let IndividualData::AstarteInteger(i32_value) = data
+                .object_data
+                .get("i32")
+                .unwrap()
+                .clone()
+                .individual_data
+                .unwrap()
+            {
+                assert_eq!(expected_i32, i32_value);
+            } else {
+                panic!();
+            }
+            if let IndividualData::AstarteDouble(f64_value) = data
+                .object_data
+                .get("f64")
+                .unwrap()
+                .clone()
+                .individual_data
+                .unwrap()
+            {
+                assert_eq!(expected_f64, f64_value);
+            } else {
+                panic!();
+            }
+        } else {
+            panic!();
+        }
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -510,6 +510,37 @@ mod test {
     }
 
     #[test]
+    fn datetime_array_into_astarte_type_individual_success() {
+        use chrono::{DateTime, Utc};
+        use std::time::SystemTime;
+
+        let expected_vec_datetime_value = vec![Utc::now(), Utc::now()];
+        let vec_datetime_astarte_individual_type: AstarteDataTypeIndividual =
+            expected_vec_datetime_value.clone().into();
+
+        if let IndividualData::AstarteDateTimeArray(vec_datetime_value) =
+            vec_datetime_astarte_individual_type
+                .individual_data
+                .unwrap()
+        {
+            for i in 0..expected_vec_datetime_value.len() {
+                let system_time: SystemTime = vec_datetime_value
+                    .values
+                    .get(i)
+                    .unwrap()
+                    .clone()
+                    .try_into()
+                    .unwrap();
+
+                let date_time: DateTime<Utc> = system_time.try_into().unwrap();
+                assert_eq!(expected_vec_datetime_value.get(i).unwrap(), &date_time);
+            }
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
     fn datetime_array_into_astarte_data_type_success() {
         use chrono::{DateTime, Utc};
         use std::time::SystemTime;


### PR DESCRIPTION
- Implements type conversion from all scalar and vector Rust type defined in the `astarte_type` proto file.
- Add tests on AstarteDataType conversion trait.
- Use plural names for repeated fields.

Closes #10.