### PR TITLE
Add Send method

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -29,58 +29,6 @@ fn main() {
 
     tonic_build::configure()
         .compile_well_known_types(true)
-        .type_attribute(
-            "AstarteDataTypeIndividual.individual_data",
-            "#[derive(serde::Serialize,serde::Deserialize)]",
-        )
-        .type_attribute(
-            "AstarteBinaryBlob",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "AstarteDateTime",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "AstarteDoubleArray",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "AstarteIntegerArray",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "AstarteBooleanArray",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "AstarteLongIntegerArray",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "AstarteStringArray",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "AstarteBinaryBlobArray",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "AstarteDateTimeArray",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "IndividualData",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "AstarteDataTypeIndividual",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "AstarteDataTypeObject",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
         .extern_path(".google.protobuf", "::pbjson_types")
         .compile(proto_files, &["proto"])
         .unwrap_or_else(|e| panic!("Failed to compile protos {:?}", e));

--- a/src/astarte_message_hub.rs
+++ b/src/astarte_message_hub.rs
@@ -306,15 +306,17 @@ mod test {
 
     #[tokio::test]
     async fn send_message_reject() {
-        use crate::error::AstarteMessageHubError::IoError;
         use crate::proto_message_hub::astarte_message::Payload;
         use crate::proto_message_hub::message_hub_server::MessageHub;
         use std::io::ErrorKind::InvalidData;
 
         let mut mock_astarte = MockAstarte::new();
-        mock_astarte
-            .expect_publish()
-            .returning(|_| Err(IoError(Error::new(InvalidData, "interface not found"))));
+        mock_astarte.expect_publish().returning(|_| {
+            Err(AstarteMessageHubError::IOError(Error::new(
+                InvalidData,
+                "interface not found",
+            )))
+        });
 
         let astarte_message_hub: AstarteMessageHub<MockAstarte> =
             AstarteMessageHub::new(mock_astarte);
@@ -334,6 +336,6 @@ mod test {
 
         assert!(send_result.is_err());
         let err: Status = send_result.err().unwrap();
-        assert_eq!("Unable to publish astarte message, err: IoError(Custom { kind: InvalidData, error: \"interface not found\" })", err.message())
+        assert_eq!("Unable to publish astarte message, err: IOError(Custom { kind: InvalidData, error: \"interface not found\" })", err.message())
     }
 }

--- a/src/astarte_message_hub.rs
+++ b/src/astarte_message_hub.rs
@@ -101,7 +101,7 @@ impl<T: AstartePublisher + AstarteSubscriber + 'static> MessageHub for AstarteMe
 
         let astarte_message = request.into_inner();
 
-        if let Err(err) = self.astarte_handler.publish(astarte_message).await {
+        if let Err(err) = self.astarte_handler.publish(&astarte_message).await {
             Err(Status::internal(format!(
                 "Unable to publish astarte message, err: {:?}",
                 err
@@ -282,7 +282,6 @@ mod test {
     async fn send_message_success() {
         use crate::proto_message_hub::astarte_message::Payload;
         use crate::proto_message_hub::message_hub_server::MessageHub;
-        use crate::proto_message_hub::Interface;
 
         let mut mock_astarte = MockAstarte::new();
         mock_astarte.expect_publish().returning(|_| Ok(()));
@@ -290,14 +289,10 @@ mod test {
         let astarte_message_hub: AstarteMessageHub<MockAstarte> =
             AstarteMessageHub::new(mock_astarte);
 
-        let interface = Interface {
-            name: "io.demo.ServerProperties".to_owned(),
-            minor: 0,
-            major: 2,
-        };
+        let interface_name = "io.demo.Values".to_owned();
 
         let astarte_message = AstarteMessage {
-            interface: Some(interface),
+            interface_name,
             path: "/test".to_string(),
             payload: Some(Payload::AstarteData(5.into())),
             timestamp: None,
@@ -311,28 +306,26 @@ mod test {
 
     #[tokio::test]
     async fn send_message_reject() {
+        use crate::error::AstarteMessageHubError::IoError;
         use crate::proto_message_hub::astarte_message::Payload;
         use crate::proto_message_hub::message_hub_server::MessageHub;
-        use crate::proto_message_hub::Interface;
+        use std::io::ErrorKind::InvalidData;
 
         let mut mock_astarte = MockAstarte::new();
         mock_astarte
             .expect_publish()
-            .returning(|_| Err(Error::new(ErrorKind::InvalidInput, "interface not found")));
+            .returning(|_| Err(IoError(Error::new(InvalidData, "interface not found"))));
 
         let astarte_message_hub: AstarteMessageHub<MockAstarte> =
             AstarteMessageHub::new(mock_astarte);
 
-        let interface = Interface {
-            name: "io.demo.ServerProperties".to_owned(),
-            minor: 0,
-            major: 2,
-        };
+        let interface_name = "io.demo.Values".to_owned();
 
+        let value: i32 = 5;
         let astarte_message = AstarteMessage {
-            interface: Some(interface),
+            interface_name,
             path: "/test".to_string(),
-            payload: Some(Payload::AstarteData(5.into())),
+            payload: Some(Payload::AstarteData(value.into())),
             timestamp: None,
         };
 
@@ -341,6 +334,6 @@ mod test {
 
         assert!(send_result.is_err());
         let err: Status = send_result.err().unwrap();
-        assert_eq!("Unable to publish astarte message, err: Custom { kind: InvalidInput, error: \"interface not found\" }", err.message())
+        assert_eq!("Unable to publish astarte message, err: IoError(Custom { kind: InvalidData, error: \"interface not found\" })", err.message())
     }
 }

--- a/src/data/mock_astarte.rs
+++ b/src/data/mock_astarte.rs
@@ -63,7 +63,7 @@ impl AstarteDeviceSdk {
         _data: T,
     ) -> Result<(), AstarteError>
     where
-        T: serde::Serialize,
+        T: astarte_device_sdk::AstarteAggregate,
     {
         todo!()
     }
@@ -76,19 +76,16 @@ impl AstarteDeviceSdk {
         _timestamp: chrono::DateTime<chrono::Utc>,
     ) -> Result<(), AstarteError>
     where
-        T: serde::Serialize,
+        T: astarte_device_sdk::AstarteAggregate,
     {
         todo!()
     }
     #[allow(dead_code)]
-    pub async fn unset<D: 'static>(
+    pub async fn unset(
         &self,
         _interface_name: &str,
         _interface_path: &str,
-    ) -> Result<(), AstarteError>
-    where
-        D: Into<AstarteType>,
-    {
+    ) -> Result<(), AstarteError> {
         todo!()
     }
     #[allow(dead_code)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,10 +22,10 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum AstarteMessageHubError {
-    #[error("")]
+    #[error(transparent)]
     Infallible(#[from] std::convert::Infallible),
 
-    #[error("")]
+    #[error(transparent)]
     TryFromIntError(#[from] core::num::TryFromIntError),
 
     #[error("Unable to convert type")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,7 @@
 
 use thiserror::Error;
 
+/// A list specifying general categories of Astarte Message Hub error.
 #[derive(Error, Debug)]
 pub enum AstarteMessageHubError {
     #[error(transparent)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -220,6 +220,9 @@ impl TryFrom<InterfaceJson> for astarte_device_sdk::Interface {
     }
 }
 
+/// This function can be used to convert a map of (String, AstarteDataTypeIndividual) into a
+/// map of (String, astarte_device_sdk::types::AstarteType).
+/// It can be useful when a method accept an astarte_device_sdk::AstarteAggregate.
 pub fn map_values_to_astarte_type(
     value: HashMap<String, AstarteDataTypeIndividual>,
 ) -> Result<HashMap<String, astarte_device_sdk::types::AstarteType>, AstarteMessageHubError> {


### PR DESCRIPTION
- Add implementation of proto Send  method.
- Add implementation of AstartePublisher.
- Add `error(transparent)` on some errors to forward the source and Display methods straight through to an underlying error without adding additional error.
- Remove `PartiEq` derive because not all errors implements it.
- Use `matches!` to compare the AstarteMessageHubError enum values.

From AstarteDeviceSDK 0.5.1 for publishing an aggregate the AstarteAggregate macro will be used, so I removed serde from `proto` types generation.

Closes #13 .