### PR TITLE
Add rust-version to cargo configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@
 name = "astarte-message-hub"
 version = "0.1.0"
 edition = "2021"
+# The minimum supported Rust version.
+# One of the effects of this flag is to disable lints pertaining to newer features.
+# See: https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field
+rust-version = "1.59"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
The `rust-version` field has been added in the `cargo.toml` file to help with linting.
When running clippy with the latest stable version of Rust, the warnings related to newer features are suppressed.
 As can be seen [here](https://github.com/rust-lang/rust-clippy#specifying-the-minimum-supported-rust-version), different approaches can be used to specify the minimum supported Rust version of clippy.
The chosen one seems the least invasive in the sources and the more likely to be supported in the future.
