### PR TITLE
feat(nix): add flake.nix and .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+use flake
+

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ target/
 *.pdb
 
 .idea/
+/.direnv/
+/result

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,3 +1,7 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: astarte-message-hub
 Source: https://https://github.com/astarte-platform/astarte-message-hub
+
+Files: flake.lock .envrc Cargo.lock
+Copyright: Copyright 2023 SECO Mind Srl
+License: Apache-2.0

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,100 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1679567394,
+        "narHash": "sha256-ZvLuzPeARDLiQUt6zSZFGOs+HZmE+3g4QURc8mkBsfM=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "88cd22380154a2c36799fe8098888f0f59861a15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1680030621,
+        "narHash": "sha256-qQa1NeS5Rvk2lgK5lSk986PC6I72yIHejzM8PFu+dHs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "402cc3633cc60dfc50378197305c984518b30773",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1679944645,
+        "narHash": "sha256-e5Qyoe11UZjVfgRfwNoSU57ZeKuEmjYb77B9IVW7L/M=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4bb072f0a8b267613c127684e099a70e1f6ff106",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1680056830,
+        "narHash": "sha256-WB4KD8oLSxAAtmXYSzwVwQusC2Gy5vTEln1uTt0GI2k=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c8d8d05b8100d451243b614d950fa3f966c1fcc2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,66 @@
+# This file is part of Astarte.
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+{
+  description = "A central service that runs on (Linux) devices for collecting and delivering messages from N apps using 1 MQTT connection to Astarte.";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+    naersk.url = "github:nix-community/naersk";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { self, nixpkgs, rust-overlay, flake-utils, naersk }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+        toolchain = pkgs.rust-bin.stable."1.59.0".default;
+        naersk' = pkgs.callPackage naersk {
+          cargo = toolchain;
+          rustc = toolchain;
+        };
+      in
+      with pkgs;
+      {
+        packages.default = naersk'.buildPackage {
+          src = ./.;
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            protobuf
+          ];
+          buildInputs = with pkgs; [
+            openssl
+          ];
+          # This is required to disable vendoring, we do not need vendoring since we are using nix.
+          OPENSSL_NO_VENDOR = 1;
+        };
+        devShells.default = mkShell {
+          packages = [
+            toolchain
+            openssl
+            pkg-config
+            protobuf
+          ];
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -39,8 +39,7 @@
           rustc = toolchain;
         };
       in
-      with pkgs;
-      {
+      rec {
         packages.default = naersk'.buildPackage {
           src = ./.;
           nativeBuildInputs = with pkgs; [
@@ -53,13 +52,8 @@
           # This is required to disable vendoring, we do not need vendoring since we are using nix.
           OPENSSL_NO_VENDOR = 1;
         };
-        devShells.default = mkShell {
-          packages = [
-            toolchain
-            openssl
-            pkg-config
-            protobuf
-          ];
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ packages.default ];
           OPENSSL_NO_VENDOR = 1;
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,7 @@
             pkg-config
             protobuf
           ];
+          OPENSSL_NO_VENDOR = 1;
         };
       }
     );


### PR DESCRIPTION
This will permit to develop using the nix shell with protoc, openssl, pkg-config and more importantly rust, pinned to a specific version.