### PR TITLE
fix(test): use temp config in tests

### DIFF
--- a/src/config/http.rs
+++ b/src/config/http.rs
@@ -187,6 +187,7 @@ mod test {
     use serial_test::serial;
     use std::collections::HashMap;
     use std::time::Duration;
+    use tempfile::TempDir;
 
     use serde_json::{Map, Number, Value};
 
@@ -196,7 +197,15 @@ mod test {
     #[serial]
     async fn server_test() {
         let (tx, mut rx) = channel(1);
-        let server = HttpConfigProvider::new("127.0.0.1:8080", tx, CONFIG_FILE_NAMES[0]);
+
+        let dir = TempDir::new().unwrap();
+        let toml_file = dir
+            .path()
+            .join(CONFIG_FILE_NAMES[0])
+            .to_string_lossy()
+            .to_string();
+
+        let server = HttpConfigProvider::new("127.0.0.1:8080", tx, &toml_file);
 
         let mut body = Map::new();
         body.insert("realm".to_string(), Value::String("realm".to_string()));
@@ -240,7 +249,15 @@ mod test {
     #[serial]
     async fn bad_request_test() {
         let (tx, _) = channel(1);
-        let server = HttpConfigProvider::new("127.0.0.1:8081", tx, CONFIG_FILE_NAMES[0]);
+
+        let dir = TempDir::new().unwrap();
+        let toml_file = dir
+            .path()
+            .join(CONFIG_FILE_NAMES[0])
+            .to_string_lossy()
+            .to_string();
+
+        let server = HttpConfigProvider::new("127.0.0.1:8081", tx, &toml_file);
 
         let mut body = HashMap::new();
         body.insert("device_id", "device_id");
@@ -266,7 +283,15 @@ mod test {
     #[serial]
     async fn test_set_config_invalid_cfg() {
         let (tx, _) = channel(1);
-        let server = HttpConfigProvider::new("127.0.0.1:8080", tx, CONFIG_FILE_NAMES[0]);
+
+        let dir = TempDir::new().unwrap();
+        let toml_file = dir
+            .path()
+            .join(CONFIG_FILE_NAMES[0])
+            .to_string_lossy()
+            .to_string();
+
+        let server = HttpConfigProvider::new("127.0.0.1:8080", tx, &toml_file);
 
         let mut body = Map::new();
         body.insert("realm".to_string(), Value::String("".to_string()));

--- a/src/config/protobuf.rs
+++ b/src/config/protobuf.rs
@@ -130,6 +130,7 @@ mod test {
     use super::*;
 
     use serial_test::serial;
+    use tempfile::TempDir;
     use tokio::sync::mpsc;
     use tonic::transport::Endpoint;
 
@@ -141,10 +142,17 @@ mod test {
         use crate::proto_message_hub::message_hub_config_server::MessageHubConfig;
         use crate::proto_message_hub::ConfigMessage;
 
+        let dir = TempDir::new().unwrap();
+        let toml_file = dir
+            .path()
+            .join(CONFIG_FILE_NAMES[0])
+            .to_string_lossy()
+            .to_string();
+
         let (tx, _) = mpsc::channel(1);
         let config_server = AstarteMessageHubConfig {
             configuration_ready_channel: tx,
-            toml_file: CONFIG_FILE_NAMES[0].to_string(),
+            toml_file,
         };
         let msg = ConfigMessage {
             realm: "rpc_realm".to_string(),
@@ -164,10 +172,17 @@ mod test {
         use crate::proto_message_hub::message_hub_config_server::MessageHubConfig;
         use crate::proto_message_hub::ConfigMessage;
 
+        let dir = TempDir::new().unwrap();
+        let toml_file = dir
+            .path()
+            .join(CONFIG_FILE_NAMES[0])
+            .to_string_lossy()
+            .to_string();
+
         let (tx, _) = mpsc::channel(1);
         let config_server = AstarteMessageHubConfig {
             configuration_ready_channel: tx,
-            toml_file: CONFIG_FILE_NAMES[0].to_string(),
+            toml_file,
         };
         let msg = ConfigMessage {
             realm: "".to_string(),
@@ -187,8 +202,15 @@ mod test {
         use crate::proto_message_hub::message_hub_config_client::MessageHubConfigClient;
         use crate::proto_message_hub::ConfigMessage;
 
+        let dir = TempDir::new().unwrap();
+        let toml_file = dir
+            .path()
+            .join(CONFIG_FILE_NAMES[0])
+            .to_string_lossy()
+            .to_string();
+
         let (tx, mut rx) = mpsc::channel(1);
-        let server = ProtobufConfigProvider::new("127.0.0.1:1400", tx, CONFIG_FILE_NAMES[0]).await;
+        let server = ProtobufConfigProvider::new("127.0.0.1:1400", tx, &toml_file).await;
         let channel = Endpoint::from_static("http://localhost:1400")
             .connect()
             .await


### PR DESCRIPTION
This solves the issue where the config file in the root of the repository would be overwritten when the tests are run.