### PR TITLE
feat(config): add a more explicative error to the validation

### DIFF
--- a/src/config/http.rs
+++ b/src/config/http.rs
@@ -86,12 +86,12 @@ impl HttpConfigProvider {
             store_directory: MessageHubOptions::default_store_directory(),
         };
 
-        if !message_hub_options.is_valid() {
+        if let Err(err) = message_hub_options.validate() {
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ConfigResponse {
                     result: "KO".to_string(),
-                    message: Some("Invalid configuration.".to_string()),
+                    message: Some(format!("Invalid configuration: {}", err)),
                 }),
             );
         }

--- a/src/config/protobuf.rs
+++ b/src/config/protobuf.rs
@@ -68,10 +68,10 @@ impl proto_message_hub::message_hub_config_server::MessageHubConfig for AstarteM
             store_directory: MessageHubOptions::default_store_directory(),
         };
 
-        if !message_hub_options.is_valid() {
+        if let Err(err) = message_hub_options.validate() {
             return Err(Status::new(
                 Code::InvalidArgument,
-                "Invalid configuration.".to_string(),
+                format!("Invalid configuration: {}.", err),
             ));
         }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use std::path::PathBuf;
+
 use thiserror::Error;
 
 /// A list specifying general categories of Astarte Message Hub error.
@@ -52,4 +54,24 @@ pub enum AstarteMessageHubError {
 
     #[error(transparent)]
     TransportError(#[from] tonic::transport::Error),
+}
+
+/// A macro to simplify the creation of a `Result` with an `AstarteMessageHubError` error type.
+#[macro_export(crate)]
+macro_rules! ensure {
+    ($cond:expr, $err:expr) => {
+        if !($cond) {
+            return Err($err);
+        }
+    };
+}
+/// Reason why a configuration is invalid.
+#[derive(Error, Debug)]
+pub enum ConfigValidationError {
+    #[error("{0} field is missing")]
+    MissingField(&'static str),
+    #[error("either the pairing token or credential secret must be provided")]
+    MissingPairingAndCredentials,
+    #[error("interface path {0:?} is not a directory")]
+    InvalidInterfaceDirectory(Option<PathBuf>),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,7 +93,7 @@ async fn initialize_astarte_device_sdk(
     }
 
     if let Some(int_dir) = &msg_hub_opts.interfaces_directory {
-        device_sdk_opts = device_sdk_opts.interface_directory(int_dir)?;
+        device_sdk_opts = device_sdk_opts.interface_directory(&int_dir.to_string_lossy())?;
     }
 
     let sdk = AstarteDeviceSdk::new(&device_sdk_opts).await?;


### PR DESCRIPTION
The validation function now returns a ConfigValidationError, which contains more information about the error. This is useful for the user to understand what's wrong with the configuration file.