### PR TITLE
 fix(docsrs): add a feature to build the docs on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,14 @@ categories = ["network-programming"]
 # See: https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field
 rust-version = "1.59.0"
 
+[features]
+# This feature should only be used for building the documentation on docs.rs, it's only a temporary
+# fix since docs.rs is using protobuf 3.12 at the moment.
+docsrs = []
+
+[package.metadata.docs.rs]
+features = ["docsrs"]
+
 [dependencies]
 tonic = "0.8.2"
 prost = "0.11.3"

--- a/build.rs
+++ b/build.rs
@@ -29,7 +29,15 @@ fn main() {
         "proto/astarteplatform/msghub/config.proto",
     ];
 
-    tonic_build::configure()
+    let mut config = tonic_build::configure();
+
+    // NOTE: This is a temporary workaround to build the documentation on docs.rs, since they are
+    //       using protobuf 3.12.
+    if cfg!(feature = "docrs") {
+        config = config.protoc_arg("--experimental_allow_proto3_optional");
+    }
+
+    config
         .compile_well_known_types(true)
         .extern_path(".google.protobuf", "::pbjson_types")
         .compile(proto_files, &["proto"])


### PR DESCRIPTION
Since docs.rs uses Ubuntu LTS the protobuf version is 3.12, which doesn't support optional fields. This patch adds a feature to build the documentation on docs.rs, which adds the `--experimental_allow_proto3_optional` flag to protoc.