### PR TITLE
 fix(docs): fix building docs on docs.rs 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,6 @@ categories = ["network-programming"]
 # See: https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field
 rust-version = "1.59.0"
 
-[features]
-# This feature should only be used for building the documentation on docs.rs, it's only a temporary
-# fix since docs.rs is using protobuf 3.12 at the moment.
-docsrs = []
-
-[package.metadata.docs.rs]
-features = ["docsrs"]
-
 [dependencies]
 tonic = "0.8.2"
 prost = "0.11.3"

--- a/build.rs
+++ b/build.rs
@@ -33,7 +33,7 @@ fn main() {
 
     // NOTE: This is a temporary workaround to build the documentation on docs.rs, since they are
     //       using protobuf 3.12.
-    if cfg!(feature = "docrs") {
+    if std::env::var("DOCS_RS").is_ok() {
         config = config.protoc_arg("--experimental_allow_proto3_optional");
     }
 


### PR DESCRIPTION
This uses the environment variable `DOCS_RS` to detect if the docs are being built on docs.rs, and if so, it adds the `--experimental_allow_proto3_optional` flag to the protoc command.

