### PR TITLE
feat(options): bump astarte sdk to v0.5.2 and expose conneciton timeout and keepalive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ target/
 *.pdb
 
 .idea/
+.pre-commit-config.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Option to configure the timeout and keep alive interval for the MQTT
+  connection to astarte.
+
 ## [0.5.2] - 2023-07-03
 ### Added
 -  Add support to receive `device_id` option from dbus.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,9 @@ checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "astarte-device-sdk"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212bcca36dfcacf39f62eed84ea400ff7dd74c18ccdfbf01c0dd039328b46afd"
+checksum = "688160018c42119b3944e2137a3522ae931d0e6e9f821a2ed9106ff37cb7758b"
 dependencies = [
  "astarte-device-sdk-derive",
  "async-trait",
@@ -78,6 +78,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "tempdir",
  "thiserror",
  "tokio",
  "url",
@@ -87,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "astarte-device-sdk-derive"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5355b4ecb5e2a4b63e8e447b2a00fed038802d26b6e29b8ddc2ee8e93acc15b"
+checksum = "523061cb889682f66797cce11b1195932db2848ac2fbbe314dc7169bedd302b6"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -346,7 +347,7 @@ dependencies = [
  "indexmap",
  "js-sys",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -735,6 +736,12 @@ name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -1757,13 +1764,26 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1773,8 +1793,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1783,6 +1818,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1819,6 +1863,15 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "reqwest"
@@ -2318,6 +2371,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2567,7 +2630,7 @@ dependencies = [
  "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -3085,7 +3148,7 @@ dependencies = [
  "nix",
  "once_cell",
  "ordered-stream",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_repr",
  "sha1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ prost = "0.11.3"
 pbjson-types = "0.5"
 chrono = "0.4.24"
 thiserror = "1.0"
-astarte-device-sdk = {version = "0.5.1" , features = ["derive"]}
+astarte-device-sdk = { version = "0.5.2" , features = ["derive"]}
 serde = "1.0.160"
 tokio = { version = "1.27.0", features = ["rt-multi-thread", "sync", "macros"] }
 tokio-stream = { version = "0.1.12", features = ["net"] }

--- a/README.md
+++ b/README.md
@@ -51,10 +51,13 @@ device_id = "[DEVICE_ID]"
 pairing_token = "[PAIRING_TOKEN]"
 # Credential secret, if not provided the `pairing_token` is required
 credentials_secret = "[CREDENTIALS_SECRET]"
-# Ignore SSL errors, defaults to false
-astarte_ignore_ssl = false
 # Path to store persistent data, defaults to "./"
-store_directory = "<STORE_PAHT>"
+store_directory = "<STORE_PATH>"
+
+
+[astarte]
+# Ignore SSL errors, defaults to false
+ignore_ssl = false
 ```
 
 An example configuration file can be found in the

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,21 +7,23 @@ SPDX-License-Identifier: Apache-2.0
 # Get started using the Astarte message hub
 
 The following examples are available to get you started with the Astarte message hub:
+
 - [client](./client/README.md): shows how to build a simple ProtoBuf client to communicate with a
-message hub server.
+  message hub server.
 
 # Common prerequisites
 
 All the examples above have some common prerequisites:
+
 - A compatible version of the [Rust toolchain](https://www.rust-lang.org/tools/install).
 - A local instance of Astarte. See
-[Astarte in 5 minutes](https://docs.astarte-platform.org/astarte/latest/010-astarte_in_5_minutes.html)
-for a quick way to set up Astarte on your machine.
+  [Astarte in 5 minutes](https://docs.astarte-platform.org/astarte/latest/010-astarte_in_5_minutes.html)
+  for a quick way to set up Astarte on your machine.
 - The [astartectl](https://github.com/astarte-platform/astartectl/releases) tool. We will use
-`astartectl` to manage the Astarte instance.
+  `astartectl` to manage the Astarte instance.
 
-**N.B.** When installing Astarte using *Astarte in 5 minutes* perform all the installation steps
-until right before the *installing the interfaces* step.
+**N.B.** When installing Astarte using _Astarte in 5 minutes_ perform all the installation steps
+until right before the _installing the interfaces_ step.
 
 ## Installing the interfaces on Astarte
 
@@ -34,24 +36,26 @@ astartectl realm-management                       \
     --realm-name <REALM>                          \
     interfaces install <INTERFACE_FILE_PATH>
 ```
+
 Where `<REALM>` is the name of the realm, and `<INTERFACE_FILE_PATH>` is the path name to the
-`.json` file containing the interface description.
-We assume you are running this command from the Astarte installation folder. If you would like to
-run it from another location provide the full path to the realm key.
+`.json` file containing the interface description. We assume you are running this command from the
+Astarte installation folder. If you would like to run it from another location provide the full path
+to the realm key.
 
 Each example contains an `/interfaces` folder. To run that example install all the interfaces
 contained in the `.json` files in that folder.
 
 ## Registering a new device on Astarte
 
-To register a new device on Astarte, two separate options are possible.
-Manual registration using a tool such `astartectl` to manage Astarte or automatic registration
-performed by the message hub requiring a pairing JWT.
+To register a new device on Astarte, two separate options are possible. Manual registration using a
+tool such `astartectl` to manage Astarte or automatic registration performed by the message hub
+requiring a pairing JWT.
 
 ### Manual registration
 
 To manually register the device on the Astarte instance you can use the following `astartectl`
 command:
+
 ```
 astartectl pairing                       \
     --pairing-url http://localhost:4003/ \
@@ -59,6 +63,7 @@ astartectl pairing                       \
     --realm-name <REALM>                 \
     agent register <DEVICE_ID>
 ```
+
 **NB**: The device id should follow a specific format. See the
 [astarte documentation](https://docs.astarte-platform.org/latest/010-design_principles.html#device-id)
 for more information regarding accepted values.
@@ -72,32 +77,39 @@ instance. This token will then be used inthe registration procedure performed in
 message hub.
 
 The command to generate a Pairing JWT is:
+
 ```
 astartectl utils gen-jwt --private-key <REALM>_private.pem pairing --expiry 0
 ```
+
 This will generate a never expiring token. To generate a token with an expiration date, then change
 `--expiry 0` to `--expiry <SEC>` with `<SEC>` the number of seconds your token should last.
 
 ## Configuring the message hub server
 
-First, we shall configure the message hub server.
-The easier way is to create a `message-hub-config.toml` file in the root of this repository.
+First, we shall configure the message hub server. The easier way is to create a
+`message-hub-config.toml` file in the root of this repository.
 
 A basic template for a manual registered device is the following:
-```
+
+```toml
 realm = "realm name"
 device_id = "device id"
 credentials_secret = "credentials secret"
 pairing_url = "http://localhost:4003"
-astarte_ignore_ssl = true
 protobuf_port = 50051
+
+[astarte]
+ignore_ssl = true
 ```
+
 If you are using the automatic registration for your device, substitute the `credentials_secret`
 with the `pairing_token` obrained in the previous step.
 
 ## Build and run the message hub server
 
 You can start the configured Astarte message hub server using the following command:
+
 ```
 cargo run
 ```
@@ -105,21 +117,24 @@ cargo run
 ## Device connection to Astarte
 
 Once the server has been started it will automatically attempt to connect the device to the local
-instance of Astarte.
-After the connection has been accomplished, the following log message should be shown:
+instance of Astarte. After the connection has been accomplished, the following log message should be
+shown:
+
 ```
 Connection to Astarte established.
 ```
 
 You can check the device used by the message hub has been correctly registered and is connected to
-the Astarte instance using `astartectl`.
-To list the all registered devices run:
+the Astarte instance using `astartectl`. To list the all registered devices run:
+
 ```
 astartectl appengine --appengine-url http://localhost:4002/ \
     --realm-key <REALM>_private.pem --realm-name <REALM>    \
     devices list
 ```
+
 You can check the status of a specific device with the command:
+
 ```
 astartectl appengine --appengine-url http://localhost:4002/ \
     --realm-key <REALM>_private.pem --realm-name <REALM>    \

--- a/examples/message-hub-config.toml
+++ b/examples/message-hub-config.toml
@@ -1,9 +1,13 @@
 realm = "example_realm"
-device_id = "YOUR_UNIQUE_DEVIDE_ID"
+device_id = "YOUR_UNIQUE_DEVICE_ID"
 pairing_url = "https://api.astarte.EXAMPLE.COM/pairing"
 grpc_socket_port = 50051
 interfaces_directory = "/usr/share/message-hub/astarte-interfaces/"
 pairing_token = "YOUR_PAIRING_TOKEN"
 # credentials_secret = "YOUR_CREDENTIAL_SECRET"
-astarte_ignore_ssl = false
 store_directory = "/var/lib/message-hub"
+
+[astarte]
+ignore_ssl = false
+# keep_alive_secs = 30
+# timeout_secs = 5

--- a/src/astarte_device_sdk_types.rs
+++ b/src/astarte_device_sdk_types.rs
@@ -418,14 +418,14 @@ mod test {
         let expected_data_f64: f64 = 15.5;
         let expected_data_i32: i32 = 15;
         let mut object_map: HashMap<String, AstarteDataTypeIndividual> = HashMap::new();
-        object_map.insert("1".to_string(), expected_data_f64.try_into().unwrap());
-        object_map.insert("2".to_string(), expected_data_i32.try_into().unwrap());
+        object_map.insert("1".to_string(), expected_data_f64.into());
+        object_map.insert("2".to_string(), expected_data_i32.into());
 
         let astarte_message = AstarteMessage {
             interface_name: interface_name.clone(),
             path: interface_path.clone(),
             timestamp: None,
-            payload: Some(Payload::AstarteData(object_map.try_into().unwrap())),
+            payload: Some(Payload::AstarteData(object_map.into())),
         };
 
         let astarte_device_data_event: AstarteDeviceDataEvent = astarte_message.try_into().unwrap();

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -69,6 +69,9 @@ mod test {
             credentials_secret = "4"
             astarte_ignore_ssl = false
             grpc_socket_port = 5
+
+            [astarte]
+            ignore_ssl = false
         "#;
 
         let res = get_options_from_toml(TOML_FILE);
@@ -78,7 +81,10 @@ mod test {
         assert_eq!(options.pairing_url, "3");
         assert_eq!(options.credentials_secret, Some("4".to_string()));
         assert_eq!(options.pairing_token, None);
-        assert!(!options.astarte_ignore_ssl);
+        #[allow(deprecated)]
+        let ignore_ssl = !options.astarte_ignore_ssl;
+        assert!(ignore_ssl);
+        assert!(!options.astarte.ignore_ssl);
         assert_eq!(options.grpc_socket_port, 5);
     }
 
@@ -91,6 +97,8 @@ mod test {
             pairing_token = "4"
             astarte_ignore_ssl = true
             grpc_socket_port = 5
+            [astarte]
+            ignore_ssl = true
         "#;
 
         let res = get_options_from_toml(TOML_FILE);
@@ -100,7 +108,10 @@ mod test {
         assert_eq!(options.pairing_url, "3");
         assert_eq!(options.credentials_secret, None);
         assert_eq!(options.pairing_token, Some("4".to_string()));
-        assert!(options.astarte_ignore_ssl);
+        #[allow(deprecated)]
+        let ignore_ssl = options.astarte_ignore_ssl;
+        assert!(ignore_ssl);
+        assert!(options.astarte.ignore_ssl);
         assert_eq!(options.grpc_socket_port, 5);
     }
 
@@ -114,6 +125,8 @@ mod test {
             pairing_token = "5"
             astarte_ignore_ssl = true
             grpc_socket_port = 6
+            [astarte]
+            ignore_ssl = true
         "#;
 
         let res = get_options_from_toml(TOML_FILE);
@@ -123,7 +136,10 @@ mod test {
         assert_eq!(options.pairing_url, "3");
         assert_eq!(options.credentials_secret, Some("4".to_string()));
         assert_eq!(options.pairing_token, Some("5".to_string()));
-        assert!(options.astarte_ignore_ssl);
+        #[allow(deprecated)]
+        let ignore_ssl = options.astarte_ignore_ssl;
+        assert!(ignore_ssl);
+        assert!(options.astarte.ignore_ssl);
         assert_eq!(options.grpc_socket_port, 6);
     }
 
@@ -135,6 +151,8 @@ mod test {
             pairing_url = "3"
             astarte_ignore_ssl = true
             grpc_socket_port = 4
+            [astarte]
+            ignore_ssl = true
         "#;
 
         let res = get_options_from_toml(TOML_FILE);
@@ -150,6 +168,8 @@ mod test {
             pairing_token = "4"
             astarte_ignore_ssl = true
             grpc_socket_port = 5
+            [astarte]
+            ignore_ssl = true
         "#;
 
         let res = get_options_from_toml(TOML_FILE);

--- a/src/config/http.rs
+++ b/src/config/http.rs
@@ -35,6 +35,8 @@ use tokio::sync::mpsc::{channel, Sender};
 
 use crate::config::MessageHubOptions;
 
+use super::DeviceSdkOptions;
+
 #[derive(Deserialize, Serialize)]
 struct ConfigResponse {
     result: String,
@@ -77,6 +79,7 @@ impl HttpConfigProvider {
         Extension(state): Extension<ConfigServerExtension>,
         Json(payload): Json<ConfigPayload>,
     ) -> impl IntoResponse {
+        #[allow(deprecated)]
         let message_hub_options = MessageHubOptions {
             realm: payload.realm,
             device_id: payload.device_id,
@@ -87,6 +90,7 @@ impl HttpConfigProvider {
             astarte_ignore_ssl: false,
             grpc_socket_port: payload.grpc_socket_port,
             store_directory: MessageHubOptions::default_store_directory(),
+            astarte: DeviceSdkOptions::default(),
         };
 
         if let Err(err) = message_hub_options.validate() {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -17,7 +17,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-//! Helper module to retreive the configuration of the Astarte message hub.
+//! Helper module to retrieve the configuration of the Astarte message hub.
 
 use std::path::{Path, PathBuf};
 use std::{fs, io};
@@ -63,6 +63,10 @@ pub struct MessageHubOptions {
     /// Directory containing the Astarte interfaces.
     pub interfaces_directory: Option<PathBuf>,
     /// Whether to ignore SSL errors when connecting to Astarte.
+    #[deprecated(
+        since = "0.5.3",
+        note = "Use the astarte map 'ignore_ssl' to configure the SDK"
+    )]
     #[serde(default)]
     pub astarte_ignore_ssl: bool,
     /// The gRPC port to use.
@@ -70,6 +74,9 @@ pub struct MessageHubOptions {
     /// Directory used by Astarte-Message-Hub to retain configuration and other persistent data.
     #[serde(default = "MessageHubOptions::default_store_directory")]
     pub store_directory: PathBuf,
+    /// Astarte device SDK options.
+    #[serde(skip_serializing_if = "DeviceSdkOptions::is_default", default)]
+    pub astarte: DeviceSdkOptions,
 }
 
 impl MessageHubOptions {
@@ -301,12 +308,27 @@ impl MessageHubOptions {
     }
 }
 
+/// Options to pass to the [Astarte device SDK](`astarte_device_sdk`).
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct DeviceSdkOptions {
+    /// Whether to ignore SSL errors when connecting to Astarte.
+    #[serde(default)]
+    pub ignore_ssl: bool,
+}
+
+impl DeviceSdkOptions {
+    fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
 
     #[test]
     fn test_is_valid_cred_sec_ok() {
+        #[allow(deprecated)]
         let expected_msg_hub_opts = MessageHubOptions {
             realm: "1".to_string(),
             device_id: Some("2".to_string()),
@@ -317,6 +339,7 @@ mod test {
             astarte_ignore_ssl: false,
             grpc_socket_port: 5,
             store_directory: MessageHubOptions::default_store_directory(),
+            astarte: DeviceSdkOptions::default(),
         };
 
         let res = expected_msg_hub_opts.validate();
@@ -325,6 +348,7 @@ mod test {
 
     #[test]
     fn test_is_valid_pairing_token_ok() {
+        #[allow(deprecated)]
         let expected_msg_hub_opts = MessageHubOptions {
             realm: "1".to_string(),
             device_id: Some("2".to_string()),
@@ -335,6 +359,7 @@ mod test {
             astarte_ignore_ssl: false,
             grpc_socket_port: 5,
             store_directory: MessageHubOptions::default_store_directory(),
+            astarte: DeviceSdkOptions::default(),
         };
 
         let res = expected_msg_hub_opts.validate();
@@ -343,6 +368,7 @@ mod test {
 
     #[test]
     fn test_is_valid_empty_realm_err() {
+        #[allow(deprecated)]
         let expected_msg_hub_opts = MessageHubOptions {
             realm: "".to_string(),
             device_id: Some("2".to_string()),
@@ -353,12 +379,14 @@ mod test {
             astarte_ignore_ssl: false,
             grpc_socket_port: 5,
             store_directory: MessageHubOptions::default_store_directory(),
+            astarte: DeviceSdkOptions::default(),
         };
         assert!(expected_msg_hub_opts.validate().is_err());
     }
 
     #[test]
     fn test_is_valid_empty_device_id() {
+        #[allow(deprecated)]
         let expected_msg_hub_opts = MessageHubOptions {
             realm: "1".to_string(),
             device_id: Some("".to_string()),
@@ -369,12 +397,14 @@ mod test {
             astarte_ignore_ssl: false,
             grpc_socket_port: 5,
             store_directory: MessageHubOptions::default_store_directory(),
+            astarte: DeviceSdkOptions::default(),
         };
         assert!(expected_msg_hub_opts.validate().is_ok());
     }
 
     #[test]
     fn test_is_valid_empty_pairing_url_err() {
+        #[allow(deprecated)]
         let expected_msg_hub_opts = MessageHubOptions {
             realm: "1".to_string(),
             device_id: Some("2".to_string()),
@@ -385,12 +415,14 @@ mod test {
             astarte_ignore_ssl: false,
             grpc_socket_port: 5,
             store_directory: MessageHubOptions::default_store_directory(),
+            astarte: DeviceSdkOptions::default(),
         };
         assert!(expected_msg_hub_opts.validate().is_err());
     }
 
     #[test]
     fn test_is_valid_empty_credentials_secred_err() {
+        #[allow(deprecated)]
         let expected_msg_hub_opts = MessageHubOptions {
             realm: "1".to_string(),
             device_id: Some("2".to_string()),
@@ -401,12 +433,14 @@ mod test {
             astarte_ignore_ssl: false,
             grpc_socket_port: 5,
             store_directory: MessageHubOptions::default_store_directory(),
+            astarte: DeviceSdkOptions::default(),
         };
         assert!(expected_msg_hub_opts.validate().is_err());
     }
 
     #[test]
     fn test_is_valid_empty_pairing_token_err() {
+        #[allow(deprecated)]
         let expected_msg_hub_opts = MessageHubOptions {
             realm: "1".to_string(),
             device_id: Some("2".to_string()),
@@ -417,12 +451,14 @@ mod test {
             astarte_ignore_ssl: false,
             grpc_socket_port: 5,
             store_directory: MessageHubOptions::default_store_directory(),
+            astarte: DeviceSdkOptions::default(),
         };
         assert!(expected_msg_hub_opts.validate().is_err());
     }
 
     #[test]
     fn test_is_valid_invalid_interf_dir_err() {
+        #[allow(deprecated)]
         let expected_msg_hub_opts = MessageHubOptions {
             realm: "1".to_string(),
             device_id: Some("2".to_string()),
@@ -433,12 +469,14 @@ mod test {
             astarte_ignore_ssl: false,
             grpc_socket_port: 5,
             store_directory: MessageHubOptions::default_store_directory(),
+            astarte: DeviceSdkOptions::default(),
         };
         assert!(expected_msg_hub_opts.validate().is_err());
     }
 
     #[test]
     fn test_is_valid_missing_credentials_secret_and_pairing_token_err() {
+        #[allow(deprecated)]
         let expected_msg_hub_opts = MessageHubOptions {
             realm: "1".to_string(),
             device_id: Some("2".to_string()),
@@ -449,6 +487,7 @@ mod test {
             astarte_ignore_ssl: false,
             grpc_socket_port: 655,
             store_directory: MessageHubOptions::default_store_directory(),
+            astarte: DeviceSdkOptions::default(),
         };
         assert!(expected_msg_hub_opts.validate().is_err());
     }
@@ -460,6 +499,7 @@ mod test {
         let dir = tempfile::TempDir::new().unwrap();
         fs::write(dir.path().join(CREDENTIAL_FILE), &expected).unwrap();
 
+        #[allow(deprecated)]
         let mut opt = MessageHubOptions {
             realm: "1".to_string(),
             device_id: Some("2".to_string()),
@@ -470,6 +510,7 @@ mod test {
             astarte_ignore_ssl: false,
             grpc_socket_port: 655,
             store_directory: dir.path().to_path_buf(),
+            astarte: DeviceSdkOptions::default(),
         };
 
         let secret = opt.obtain_credential_secret().await;
@@ -486,6 +527,7 @@ mod test {
     async fn obtain_credential_secret_register_device() {
         let dir = tempfile::TempDir::new().unwrap();
 
+        #[allow(deprecated)]
         let mut opt = MessageHubOptions {
             realm: "1".to_string(),
             device_id: Some("2".to_string()),
@@ -496,6 +538,7 @@ mod test {
             astarte_ignore_ssl: false,
             grpc_socket_port: 655,
             store_directory: dir.path().to_path_buf(),
+            astarte: DeviceSdkOptions::default(),
         };
 
         let secret = opt.obtain_credential_secret().await;
@@ -515,6 +558,7 @@ mod test {
 
     #[tokio::test]
     async fn load_toml_config() {
+        #[allow(deprecated)]
         let expected = MessageHubOptions {
             realm: "1".to_string(),
             device_id: Some("2".to_string()),
@@ -525,6 +569,7 @@ mod test {
             astarte_ignore_ssl: false,
             grpc_socket_port: 655,
             store_directory: MessageHubOptions::default_store_directory(),
+            astarte: DeviceSdkOptions::default(),
         };
 
         let dir = tempfile::TempDir::new().unwrap();
@@ -543,6 +588,7 @@ mod test {
 
     #[tokio::test]
     async fn load_from_store_path() {
+        #[allow(deprecated)]
         let mut expected = MessageHubOptions {
             realm: "1".to_string(),
             device_id: Some("2".to_string()),
@@ -553,6 +599,7 @@ mod test {
             astarte_ignore_ssl: false,
             grpc_socket_port: 655,
             store_directory: MessageHubOptions::default_store_directory(),
+            astarte: DeviceSdkOptions::default(),
         };
 
         let dir = tempfile::TempDir::new().unwrap();
@@ -580,6 +627,7 @@ mod test {
         assert!(opts.is_ok(), "error deserializing config: {:?}", opts);
         let opts = opts.unwrap();
 
+        #[allow(deprecated)]
         let expected = MessageHubOptions {
             realm: "example_realm".to_string(),
             device_id: Some("YOUR_UNIQUE_DEVICE_ID".to_string()),
@@ -590,6 +638,7 @@ mod test {
             astarte_ignore_ssl: false,
             grpc_socket_port: 50051,
             store_directory: PathBuf::from("/var/lib/message-hub"),
+            astarte: DeviceSdkOptions::default(),
         };
 
         assert_ne!(opts, expected);
@@ -602,6 +651,7 @@ mod test {
         let dir = tempfile::TempDir::new().unwrap();
         fs::write(dir.path().join(CREDENTIAL_FILE), &expected).unwrap();
 
+        #[allow(deprecated)]
         let mut opt = MessageHubOptions {
             realm: "1".to_string(),
             device_id: Some("2".to_string()),
@@ -612,6 +662,7 @@ mod test {
             astarte_ignore_ssl: false,
             grpc_socket_port: 655,
             store_directory: dir.path().to_path_buf(),
+            astarte: DeviceSdkOptions::default(),
         };
 
         let device_id = opt.obtain_device_id().await;
@@ -631,6 +682,7 @@ mod test {
         let dir = tempfile::TempDir::new().unwrap();
         fs::write(dir.path().join(CREDENTIAL_FILE), &expected).unwrap();
 
+        #[allow(deprecated)]
         let mut opt = MessageHubOptions {
             realm: "1".to_string(),
             device_id: None,
@@ -641,6 +693,7 @@ mod test {
             astarte_ignore_ssl: false,
             grpc_socket_port: 655,
             store_directory: dir.path().to_path_buf(),
+            astarte: DeviceSdkOptions::default(),
         };
 
         let device_id = opt.obtain_device_id().await;
@@ -660,6 +713,7 @@ mod test {
         let dir = tempfile::TempDir::new().unwrap();
         fs::write(dir.path().join(CREDENTIAL_FILE), &expected).unwrap();
 
+        #[allow(deprecated)]
         let mut opt = MessageHubOptions {
             realm: "1".to_string(),
             device_id: Some("".to_string()),
@@ -670,6 +724,7 @@ mod test {
             astarte_ignore_ssl: false,
             grpc_socket_port: 655,
             store_directory: dir.path().to_path_buf(),
+            astarte: DeviceSdkOptions::default(),
         };
 
         let device_id = opt.obtain_device_id().await;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -310,7 +310,16 @@ impl MessageHubOptions {
 
 /// Options to pass to the [Astarte device SDK](`astarte_device_sdk`).
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename = "astarte")]
 pub struct DeviceSdkOptions {
+    /// Keep alive interval.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keep_alive_secs: Option<u64>,
+    /// Connection timeout.
+    ///
+    /// Should be less than the keep alive interval.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
     /// Whether to ignore SSL errors when connecting to Astarte.
     #[serde(default)]
     pub ignore_ssl: bool,

--- a/src/config/protobuf.rs
+++ b/src/config/protobuf.rs
@@ -31,6 +31,8 @@ use tonic::{Code, Request, Response, Status};
 use crate::config::MessageHubOptions;
 use crate::proto_message_hub;
 
+use super::DeviceSdkOptions;
+
 #[derive(Debug)]
 struct AstarteMessageHubConfig {
     configuration_ready_channel: Sender<()>,
@@ -59,6 +61,7 @@ impl proto_message_hub::message_hub_config_server::MessageHubConfig for AstarteM
                 Status::new(Code::InvalidArgument, format!("Invalid grpc port: {}", err))
             })?;
 
+        #[allow(deprecated)]
         let message_hub_options = MessageHubOptions {
             realm: req.realm,
             device_id: req.device_id,
@@ -69,6 +72,7 @@ impl proto_message_hub::message_hub_config_server::MessageHubConfig for AstarteM
             astarte_ignore_ssl: false,
             grpc_socket_port: port,
             store_directory: MessageHubOptions::default_store_directory(),
+            astarte: DeviceSdkOptions::default(),
         };
 
         if let Err(err) = message_hub_options.validate() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@
 
 use std::net::Ipv6Addr;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use clap::Parser;
 use log::info;
@@ -99,6 +100,14 @@ async fn initialize_astarte_device_sdk(
     #[allow(deprecated)]
     if msg_hub_opts.astarte_ignore_ssl || msg_hub_opts.astarte.ignore_ssl {
         device_sdk_opts = device_sdk_opts.ignore_ssl_errors();
+    }
+
+    if let Some(timeout) = msg_hub_opts.astarte.timeout_secs {
+        device_sdk_opts = device_sdk_opts.connection_timeout(Duration::from_secs(timeout));
+    }
+
+    if let Some(keep_alive) = msg_hub_opts.astarte.keep_alive_secs {
+        device_sdk_opts = device_sdk_opts.keepalive(Duration::from_secs(keep_alive));
     }
 
     if let Some(int_dir) = &msg_hub_opts.interfaces_directory {

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,8 @@ async fn initialize_astarte_device_sdk(
         &msg_hub_opts.pairing_url,
     );
 
-    if msg_hub_opts.astarte_ignore_ssl {
+    #[allow(deprecated)]
+    if msg_hub_opts.astarte_ignore_ssl || msg_hub_opts.astarte.ignore_ssl {
         device_sdk_opts = device_sdk_opts.ignore_ssl_errors();
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -560,8 +560,8 @@ mod test {
             .unwrap();
 
         if let IndividualData::AstarteDateTime(date_time_value) = data {
-            let resul_date_time: DateTime<Utc> = date_time_value.try_into().unwrap();
-            assert_eq!(expected_datetime_value, resul_date_time);
+            let result_date_time: DateTime<Utc> = date_time_value.try_into().unwrap();
+            assert_eq!(expected_datetime_value, result_date_time);
         } else {
             panic!();
         }


### PR DESCRIPTION
This will expose the connection timeout and keep alive from the new version of the Astarte SDK.

The options related to the Astarte MQTT connection have been moved to a separate struct, while still supporting the old fields.

Closes #200