### PR TITLE
fix(interface):  make the interface dir not error

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ credentials_secret = "[CREDENTIALS_SECRET]"
 # Path to store persistent data, defaults to "./"
 store_directory = "<STORE_PATH>"
 
-
 [astarte]
 # Ignore SSL errors, defaults to false
 ignore_ssl = false


### PR DESCRIPTION
Don't error if the interface directory is missing.

Reverti the a regression that slipt into by https://github.com/astarte-platform/astarte-message-hub/pull/215 we should be able to start the message hub without interfaces.