### PR TITLE
fix(config): expose the `pairing_url` to the cli and env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.3] - Unreleased
+
+### Added
+
+- Add the `pairing_url` configuration option to the cmdline `--pairing-url` and environment variable
+  `MSGHUB_PAIRING_URL`. [#334](https://github.com/astarte-platform/astarte-message-hub/pull/334)
+
 ## [0.7.2] - 2025-03-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The format for the configuration file is the following:
 # Required fields
 #
 realm = "<REALM>"
+# Required to comunicate with Astarte.
 pairing_url = "<PAIRING_URL>"
 # Used to register a device and obtain a `credentials_secret`
 pairing_token = "[PAIRING_TOKEN]"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,6 +102,9 @@ pub struct DeviceOptions {
     /// A unique ID for the device.
     #[arg(long, env = "MSGHUB_DEVICE_ID")]
     pub device_id: Option<String>,
+    /// Pairing URL of the Astarte instance.
+    #[arg(long, env = "MSGHUB_PAIRING_URL")]
+    pub pairing_url: Option<String>,
     /// The credentials secret used to authenticate with Astarte.
     #[arg(
         long,
@@ -128,6 +131,7 @@ impl DeviceOptions {
     pub fn merge(self, config: &mut Config) {
         config.realm.merge(self.realm);
         config.device_id.merge(self.device_id);
+        config.pairing_url.merge(self.pairing_url);
         config.credentials_secret.merge(self.credentials_secret);
         config.pairing_token.merge(self.pairing_token);
         config.interfaces_directory.merge(self.interfaces_dir);


### PR DESCRIPTION
Add a new cli flag `--pairing-url` and `MSGHUB_PAIRING_URL` env as configuration options.

Closes #333 