### PR TITLE
refactor(log): use tracing_subscriber for a better log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,6 @@ dependencies = [
  "chrono",
  "clap",
  "displaydoc",
- "env_logger",
  "eyre",
  "futures",
  "hyper",
@@ -218,6 +217,7 @@ dependencies = [
  "toml",
  "tonic",
  "tower 0.5.2",
+ "tracing-subscriber",
  "uuid",
  "zbus",
 ]
@@ -949,29 +949,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
-]
-
-[[package]]
-name = "env_filter"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
 ]
 
 [[package]]
@@ -1775,30 +1752,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "jiff"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c102670231191d07d37a35af3eb77f1f0dbf7a71be51a962dcd57ea607be7260"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdde31a9d349f1b1f51a0b3714a5940ac022976f4b49485fc04be052b183b4c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2332,21 +2285,6 @@ dependencies = [
  "rustix 0.38.44",
  "tracing",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "portable-atomic"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ axum = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 displaydoc = { workspace = true }
-env_logger = { workspace = true }
 eyre = { workspace = true }
 futures = { workspace = true }
 hyper = { workspace = true }
@@ -55,6 +54,7 @@ tokio-util = { workspace = true }
 toml = { workspace = true }
 tonic = { workspace = true }
 tower = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uuid = { workspace = true }
 zbus = { workspace = true, default-features = false, features = ["tokio"] }
 
@@ -79,7 +79,6 @@ chrono = "0.4.38"
 clap = "4.5.36"
 color-eyre = "0.6.3"
 displaydoc = "0.2.5"
-env_logger = "0.11.3"
 eyre = "0.6.12"
 futures = "0.3.30"
 hyper = "1.5.1"

--- a/e2e-test/src/main.rs
+++ b/e2e-test/src/main.rs
@@ -298,7 +298,7 @@ async fn send_device_data(node: &Node, api: &Api, barrier: &Barrier) -> eyre::Re
     for prop in stored_prop {
         let exp_value = data
             .remove(prop.path.trim_start_matches('/'))
-            .ok_or_eyre(format!("endpoint not found for prop {:#?}", prop))?;
+            .ok_or_eyre(format!("endpoint not found for prop {prop:#?}"))?;
         assert_eq!(exp_value, prop.value);
     }
 

--- a/examples/client/main.rs
+++ b/examples/client/main.rs
@@ -31,6 +31,9 @@ use log::{error, info};
 use std::time;
 use tokio::signal::ctrl_c;
 use tokio::task::JoinSet;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
 
 const DEVICE_DATASTREAM: &str = include_str!(
@@ -66,10 +69,13 @@ type DynError = Box<dyn std::error::Error + Send + Sync + 'static>;
 #[tokio::main]
 async fn main() -> Result<(), DynError> {
     stable_eyre::install()?;
-    env_logger::try_init()?;
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .try_init()?;
 
     let args = Cli::parse();
-    let node_id = Uuid::parse_str(&args.uuid)?;
+    let node_id: Uuid = Uuid::parse_str(&args.uuid)?;
 
     let grpc_cfg = GrpcConfig::from_url(node_id, args.endpoint)?;
 

--- a/src/config/http.rs
+++ b/src/config/http.rs
@@ -78,19 +78,19 @@ impl IntoResponse for ErrorResponse {
         let (status, msg) = match self {
             ErrorResponse::InvalidConfig(err) => (
                 StatusCode::BAD_REQUEST,
-                format!("Invalid configuration: {}", err),
+                format!("Invalid configuration: {err}"),
             ),
             ErrorResponse::Serialize(err) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Error in config serialization, {}", err),
+                format!("Error in config serialization, {err}"),
             ),
             ErrorResponse::Write(err) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Unable to write in toml file, {}", err),
+                format!("Unable to write in toml file, {err}"),
             ),
             ErrorResponse::Channel(err) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Channel error, {}", err),
+                format!("Channel error, {err}"),
             ),
         };
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -241,7 +241,7 @@ impl Config {
 
         match fs::read_to_string(&path).await {
             Ok(cred) => {
-                debug!("using stored credentials from {:?}", path);
+                debug!("using stored credentials from {path:?}");
 
                 self.credentials_secret = Some(cred);
             }
@@ -469,7 +469,7 @@ mod test {
         };
 
         let res = expected_msg_hub_opts.validate();
-        assert!(res.is_ok(), "{:?}", res);
+        assert!(res.is_ok(), "{res:?}");
         MessageHubOptions::try_from(expected_msg_hub_opts).unwrap();
     }
 
@@ -748,7 +748,7 @@ mod test {
 
         let opts = toml::from_str::<Config>(config);
 
-        assert!(opts.is_ok(), "error deserializing config: {:?}", opts);
+        assert!(opts.is_ok(), "error deserializing config: {opts:?}");
         let opts = opts.unwrap();
 
         #[allow(deprecated)]
@@ -826,8 +826,7 @@ mod test {
 
         assert!(
             device_id.is_ok(),
-            "error obtaining stored credential {:?}",
-            device_id
+            "error obtaining stored credential {device_id:?}"
         );
         assert_eq!(opt.device_id.unwrap(), expected);
     }

--- a/src/config/protobuf.rs
+++ b/src/config/protobuf.rs
@@ -81,7 +81,7 @@ impl MessageHubConfig for AstarteMessageHubConfig {
             .map(|host| IpAddr::from_str(&host))
             .transpose()
             .map_err(|err| {
-                Status::new(Code::InvalidArgument, format!("Invalid grpc host: {}", err))
+                Status::new(Code::InvalidArgument, format!("Invalid grpc host: {err}"))
             })?;
 
         // Protobuf version 3 only supports u32
@@ -90,7 +90,7 @@ impl MessageHubConfig for AstarteMessageHubConfig {
             .map(u16::try_from)
             .transpose()
             .map_err(|err: TryFromIntError| {
-                Status::new(Code::InvalidArgument, format!("Invalid grpc port: {}", err))
+                Status::new(Code::InvalidArgument, format!("Invalid grpc port: {err}"))
             })?;
 
         #[allow(deprecated)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -100,7 +100,7 @@ where
         let interfaces_json = InterfacesJson::from_iter(node.interfaces_json);
         let astarte_node = AstarteNode::from_json(node_id, &interfaces_json)?;
 
-        info!("Node attached {:?}", astarte_node);
+        info!("Node attached {astarte_node:?}");
 
         let sub = self.astarte_handler.subscribe(&astarte_node).await?;
 
@@ -606,7 +606,7 @@ where
         let astarte_message = request.into_inner();
 
         if let Err(err) = self.astarte_handler.publish(&astarte_message).await {
-            let err_msg = format!("Unable to publish astarte message, err: {:?}", err);
+            let err_msg = format!("Unable to publish astarte message, err: {err:?}");
             error!("{err_msg}");
             Err(Status::internal(err_msg))
         } else {


### PR DESCRIPTION
By using the tracing subscriber Registry layer we are able to better track active spans, thus fixing some of the logs in which the statement was an empty line with info level