### PR TITLE
fix(deps): specify version for aws-lc-rs and rusqlite to avoid cargo publish error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,8 @@ zbus = { workspace = true, default-features = false, features = ["tokio"] }
 native-tls = { workspace = true }
 
 # C dependencies
-aws-lc-rs = { version = "*", optional = true }
-rusqlite = { version = "*", optional = true }
+aws-lc-rs = { version = "1.12.5", optional = true }
+rusqlite = { version = "0.29.0", optional = true }
 
 [dev-dependencies]
 astarte-device-sdk-mock = { workspace = true }


### PR DESCRIPTION
Solve the error depicted [here](https://doc.rust-lang.org/cargo/faq.html#can-libraries-use--as-a-version-for-their-dependencies)