### PR TITLE
feat(dynamic): configure fdo pairing via HTTP

### DIFF
--- a/snapshots/astarte_message_hub__config__file__fdo__tests__fdo_config_roundtrip.snap
+++ b/snapshots/astarte_message_hub__config__file__fdo__tests__fdo_config_roundtrip.snap
@@ -1,0 +1,6 @@
+---
+source: src/config/file/fdo.rs
+expression: toml
+---
+enabled = true
+manufacturing_url = "https://example.com/"

--- a/src/config/dynamic/http.rs
+++ b/src/config/dynamic/http.rs
@@ -36,7 +36,9 @@ use tokio::task::{JoinError, JoinSet};
 use tokio_util::sync::CancellationToken;
 use tower_http::trace::TraceLayer;
 use tracing::{error, info};
+use url::Url;
 
+use crate::config::file::fdo::FdoConfig;
 use crate::config::loader::ConfigEntry;
 use crate::error::ConfigError;
 use crate::store::StoreDir;
@@ -174,13 +176,14 @@ impl ConfigServer {
 
 #[derive(Debug, Clone, Deserialize)]
 struct ConfigPayload {
-    realm: String,
+    realm: Option<String>,
     device_id: Option<String>,
     credentials_secret: Option<String>,
-    pairing_url: String,
+    pairing_url: Option<String>,
     pairing_token: Option<String>,
     grpc_socket_host: Option<IpAddr>,
     grpc_socket_port: Option<u16>,
+    fdo: Option<FdoPayload>,
 }
 
 impl TryFrom<ConfigPayload> for Config {
@@ -195,22 +198,46 @@ impl TryFrom<ConfigPayload> for Config {
             pairing_token,
             grpc_socket_host,
             grpc_socket_port,
+            fdo,
         } = value;
 
+        let fdo = fdo.map(FdoConfig::from);
+
         let config = Self {
-            realm: Some(realm),
+            realm,
             device_id,
             credentials_secret,
-            pairing_url: Some(pairing_url),
+            pairing_url,
             pairing_token,
             grpc_socket_host,
             grpc_socket_port,
+            fdo,
             ..Default::default()
         };
 
         config.validate()?;
 
         Ok(config)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct FdoPayload {
+    enabled: Option<bool>,
+    manufacturing_url: Option<Url>,
+}
+
+impl From<FdoPayload> for FdoConfig {
+    fn from(value: FdoPayload) -> Self {
+        let FdoPayload {
+            enabled,
+            manufacturing_url,
+        } = value;
+
+        FdoConfig {
+            enabled,
+            manufacturing_url,
+        }
     }
 }
 
@@ -396,19 +423,25 @@ mod test {
 
     #[rstest]
     #[timeout(Duration::from_secs(2))]
+    #[case(Config {
+        realm: Some("realm".to_string()),
+        device_id: Some("device_id".to_string()),
+        pairing_url: Some("pairing_url".to_string()),
+        credentials_secret: Some("credentials_secret".to_string()),
+        ..Default::default()
+    })]
+    #[case(Config {
+        fdo: Some(FdoConfig {
+            enabled: Some(true),
+            manufacturing_url: Some("http://example.com".parse().unwrap())
+        }),
+        ..Default::default()
+    })]
     #[tokio::test]
-    async fn server_test() {
+    async fn server_test(#[case] exp: Config) {
         let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
         let mut server = TestServer::serve().await;
-
-        let exp = Config {
-            realm: Some("realm".to_string()),
-            device_id: Some("device_id".to_string()),
-            pairing_url: Some("pairing_url".to_string()),
-            credentials_secret: Some("credentials_secret".to_string()),
-            ..Default::default()
-        };
 
         let client = reqwest::Client::new();
 
@@ -444,19 +477,25 @@ mod test {
 
     #[rstest]
     #[timeout(Duration::from_secs(2))]
+    #[case(Config {
+        realm: Some("realm".to_string()),
+        device_id: Some("device_id".to_string()),
+        pairing_url: Some("pairing_url".to_string()),
+        credentials_secret: Some("credentials_secret".to_string()),
+        ..Default::default()
+    })]
+    #[case(Config {
+        fdo: Some(FdoConfig {
+            enabled: Some(true),
+            manufacturing_url: Some("http://example.com".parse().unwrap())
+        }),
+        ..Default::default()
+    })]
     #[tokio::test]
-    async fn server_upload_test() {
+    async fn server_upload_test(#[case] exp: Config) {
         let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
         let mut server = TestServer::serve().await;
-
-        let exp = Config {
-            realm: Some("realm".to_string()),
-            device_id: Some("device_id".to_string()),
-            pairing_url: Some("pairing_url".to_string()),
-            credentials_secret: Some("credentials_secret".to_string()),
-            ..Default::default()
-        };
 
         let client = reqwest::Client::new();
 

--- a/src/config/file/fdo.rs
+++ b/src/config/file/fdo.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::config::Override;
+use crate::error::ConfigError;
 
 /// Configures the FDO Onboarding protocol
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -36,6 +37,20 @@ pub struct FdoConfig {
     pub manufacturing_url: Option<Url>,
 }
 
+impl FdoConfig {
+    pub(crate) fn validate(&self) -> Result<(), ConfigError> {
+        if self.enabled.is_none_or(|enabled| !enabled) {
+            return Ok(());
+        }
+
+        if self.manufacturing_url.is_none() {
+            return Err(ConfigError::MissingField("manufacturing_url"));
+        }
+
+        Ok(())
+    }
+}
+
 impl Override for FdoConfig {
     fn merge(&mut self, overrides: Self) {
         let Self {
@@ -48,4 +63,61 @@ impl Override for FdoConfig {
     }
 }
 
-// TODO add insta tests
+#[cfg(test)]
+mod tests {
+    use crate::tests::with_settings;
+
+    use super::*;
+
+    #[test]
+    fn fdo_config_roundtrip() {
+        let fdo = FdoConfig {
+            enabled: Some(true),
+            manufacturing_url: Some("https://example.com".parse().unwrap()),
+        };
+
+        let toml = toml::to_string_pretty(&fdo).unwrap();
+
+        let res: FdoConfig = toml::from_str(&toml).unwrap();
+
+        pretty_assertions::assert_eq!(res, fdo);
+
+        with_settings!({
+            insta::assert_snapshot!(toml);
+        });
+    }
+
+    #[rstest::rstest]
+    #[case(FdoConfig {
+        enabled: Some(true),
+        manufacturing_url: Some("https://example.com".parse().unwrap()),
+    })]
+    #[case(FdoConfig {
+        enabled: Some(false),
+        manufacturing_url: Some("https://example.com".parse().unwrap()),
+    })]
+    #[case(FdoConfig {
+        enabled: None,
+        manufacturing_url: Some("https://example.com".parse().unwrap()),
+    })]
+    #[case(FdoConfig {
+        enabled: Some(false),
+        manufacturing_url: None,
+    })]
+    #[case(FdoConfig {
+        enabled: None,
+        manufacturing_url: None,
+    })]
+    fn should_validate_ok(#[case] case: FdoConfig) {
+        case.validate().unwrap();
+    }
+
+    #[rstest::rstest]
+    #[case(FdoConfig {
+        enabled: Some(true),
+        manufacturing_url: None,
+    })]
+    fn should_validate_invalid(#[case] case: FdoConfig) {
+        case.validate().unwrap_err();
+    }
+}

--- a/src/config/file/mod.rs
+++ b/src/config/file/mod.rs
@@ -222,12 +222,12 @@ impl Config {
 
     /// Validate the values are present for the server configuration.
     pub fn validate(&self) -> Result<(), ConfigError> {
-        if self
-            .fdo
-            .as_ref()
-            .is_some_and(|fdo| fdo.enabled.unwrap_or_default())
+        if let Some(fdo) = &self.fdo.as_ref()
+            && fdo.enabled.unwrap_or_default()
         {
             info!("FDO is enabled");
+
+            fdo.validate()?;
         } else {
             self.validate_pairing_config()?;
         }


### PR DESCRIPTION
Add Fdo configuration to the HTTP config payload. This will be an
additional field to the Config json called `fdo`, as a document with fields:

- `enabled (boolean)`: to enalbe pairing via FDO
- `manufactoring_url (string)`: a valid URL to the manufactoring server

The configuration is validated so if the fdo is enable it will return error if the manufacturing URL is missing.