### PR TITLE
feat(docs): document the dynamic config

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ An example configuration file can be found in the
 [examples](https://github.com/astarte-platform/astarte-message-hub/blob/master/examples/message-hub-config.toml)
 direction.
 
+For the full list of the available fields of the configuration file, you can look at the
+[Config struct on in the documentation](https://docs.rs/astarte-message-hub/latest/astarte_message_hub/config/file/struct.Config.html).
+
 #### Configuration priority
 
 The Message Hub will first load the default configuration files in the system and user directory, in
@@ -104,6 +107,25 @@ by one named `40-config.toml`.
 
 After all the configuration files, the custom configuration file (specified with the `-c` or
 `--config` flag) and other CLI and ENV arguments will take be read.
+
+#### Dynamic configuration
+
+If the message-hub is started with the dynamic configuration option enable, either from CLI or
+configuration file. It will start the HTTP and/or the gRPC and wait for a configuration to be
+provided.
+
+The configuration will be then stored if a store directory has been provided, and it's not required
+for future restarts.
+
+You can update the configuration with subsequent calls to the dynamic configuration API, and this
+will make the message-hub restart and reload the configuration.
+
+Although, if the device is already is already paired with Astarte not all the fields can be changed.
+The `device-id`, `realm` and `pairing-url` must remain the same after registering the device, while
+you can change the `credential_secret` since it can be wiped from Astarte.
+
+You can find the
+[HTTP api described in the docs.](https://docs.rs/astarte-message-hub/latest/astarte_message_hub/config/dynamic/http/index.html)
 
 ### Configuration in docker
 

--- a/src/config/dynamic/http.rs
+++ b/src/config/dynamic/http.rs
@@ -17,6 +17,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Provides an HTTP API to set The Message Hub configurations
+//!
+//! The API has the following endpoints:
+//!
+//! - `GET /` to check the status of the server
+//! - `POST /config` to upload the configuration file [`CONFIG_FILE_NAME_NO_EXT`]
+//! - `PUT /config/upload/<file_name>` to upload the configuration file and customize the file name,
+//!   for example with a priority like `99-config.toml`
+//!
+//! You can pass `?store=false` in the query parameter to choose whether to store the uploaded
+//! configuration file.
+//!
+//! The payload must be in the format of [`ConfigPayload`]
 
 use std::io;
 use std::net::{IpAddr, SocketAddr};
@@ -174,16 +186,40 @@ impl ConfigServer {
     }
 }
 
+/// Json payload for the configuration API.
+///
+/// The fields are optional and will be validated with all the other configurations.
+///
+/// ### Example
+///
+/// ```json
+/// {
+///     realm: "test",
+///     device_id: "wCVUPizcTNatmidLgHBMjw",
+///     credentials_secret: "CREDENTIALS_SECRET"
+///     pairing_url: "http://api.astarte.localhost/pairing",
+/// }
+/// ```
 #[derive(Debug, Clone, Deserialize)]
-struct ConfigPayload {
-    realm: Option<String>,
-    device_id: Option<String>,
-    credentials_secret: Option<String>,
-    pairing_url: Option<String>,
-    pairing_token: Option<String>,
-    grpc_socket_host: Option<IpAddr>,
-    grpc_socket_port: Option<u16>,
-    fdo: Option<FdoPayload>,
+pub struct ConfigPayload {
+    /// Device Astarte realm
+    pub realm: Option<String>,
+    /// Device ID registered on Astarte
+    pub device_id: Option<String>,
+    /// Credential secret of an already registered device.
+    pub credentials_secret: Option<String>,
+    /// Astarte pairing URL
+    pub pairing_url: Option<String>,
+    /// JWT token with pairing claim.
+    pub pairing_token: Option<String>,
+    /// gRPC host to start the message-hub on.
+    pub grpc_socket_host: Option<IpAddr>,
+    /// gRPC port to start the message-hub on.
+    pub grpc_socket_port: Option<u16>,
+    /// FDO configuration.
+    ///
+    /// Used instead to provide paring token or secret.
+    pub fdo: Option<FdoPayload>,
 }
 
 impl TryFrom<ConfigPayload> for Config {
@@ -221,10 +257,13 @@ impl TryFrom<ConfigPayload> for Config {
     }
 }
 
+/// FDO configuration
 #[derive(Debug, Clone, Deserialize)]
-struct FdoPayload {
-    enabled: Option<bool>,
-    manufacturing_url: Option<Url>,
+pub struct FdoPayload {
+    /// Enable pairing with FDO
+    pub enabled: Option<bool>,
+    /// URL of the manufacturing server
+    pub manufacturing_url: Option<Url>,
 }
 
 impl From<FdoPayload> for FdoConfig {

--- a/src/config/file/mod.rs
+++ b/src/config/file/mod.rs
@@ -56,6 +56,44 @@ pub const LEGACY_CONFIG_FILE_NAME: &str = "message-hub-config.toml";
 const LEGACY_CREDENTIAL_FILE: &str = "credentials_secret";
 
 /// Struct to deserialize the configuration options for the Astarte message hub.
+///
+/// This will be deserialized from a file using [`toml`].
+///
+/// ### Example
+///
+/// ```toml
+/// ##
+/// # Required fields
+/// #
+/// realm = "<REALM>"
+/// # Required to communicate with Astarte.
+/// pairing_url = "<PAIRING_URL>"
+/// # Used to register a device and obtain a `credentials_secret`
+/// pairing_token = "[PAIRING_TOKEN]"
+/// # Credential secret, if not provided the `pairing_token` is required
+/// credentials_secret = "[CREDENTIALS_SECRET]"
+/// # Device id, if not provided it will be retrieved from `io.edgehog.Device` dbus-service
+/// device_id = "[DEVICE_ID]"
+/// # Path to store persistent data
+/// store_directory = "[STORE_DIRECTORY]"
+///
+/// ##
+/// # Optional fields
+/// #
+/// # Directory containing the JSON interfaces
+/// interfaces_directory = "[INTERFACES_DIRECTORY]"
+///
+/// ##
+/// # Other fields, with defaults
+/// #
+/// # Address the gRPC connection will bind to
+/// grpc_socket_host = "127.0.0.1"
+/// grpc_socket_port = 50051
+///
+/// [astarte]
+/// # Ignore SSL errors
+/// ignore_ssl = false
+/// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Config {
     /// The Astarte realm the device belongs to.


### PR DESCRIPTION
Add documentation for the dynamic config and HTTP API. Make public the config file and JSON payload.

Specify that when a device is paired, you cannot change the device_id, realm or pairing URL.